### PR TITLE
Add html_to! macro

### DIFF
--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -18,7 +18,7 @@ extern crate maud_macros;
 
 use std::fmt::{self, Write};
 
-pub use maud_macros::{html, html_debug};
+pub use maud_macros::{html, html_to, html_debug, html_to_debug};
 
 /// Represents a type that can be rendered as HTML.
 ///

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -5,190 +5,198 @@
 
 extern crate maud;
 
-use maud::{Markup, html};
+use maud::{html, html_to};
+
+#[macro_use]
+mod html_test;
 
 #[test]
 fn literals() {
-    let s = html!("du\tcks" "-23" "3.14\n" "geese").into_string();
-    assert_eq!(s, "du\tcks-233.14\ngeese");
+    html_test!(assert_eq: "du\tcks-233.14\ngeese",
+               markup: "du\tcks" "-23" "3.14\n" "geese");
 }
 
 #[test]
 fn escaping() {
-    let s = html!("<flim&flam>").into_string();
-    assert_eq!(s, "&lt;flim&amp;flam&gt;");
+    html_test!(assert_eq: "&lt;flim&amp;flam&gt;",
+               markup: "<flim&flam>");
 }
 
 #[test]
 fn semicolons() {
-    let s = html! {
-        "one";
-        "two";
-        "three";
-        ;;;;;;;;;;;;;;;;;;;;;;;;
-        "four";
-    }.into_string();
-    assert_eq!(s, "onetwothreefour");
+    html_test!(assert_eq: "onetwothreefour",
+               markup:
+               "one";
+               "two";
+               "three";
+               ;;;;;;;;;;;;;;;;;;;;;;;;
+               "four";);
 }
 
 #[test]
 fn blocks() {
-    let s = html! {
-        "hello"
-        {
-            " ducks" " geese"
-        }
-        " swans"
-    }.into_string();
-    assert_eq!(s, "hello ducks geese swans");
+    html_test!(assert_eq: "hello ducks geese swans",
+               markup:
+               "hello"
+               {
+                   " ducks" " geese"
+               }
+               " swans"
+    );
 }
 
 #[test]
 fn simple_elements() {
-    let s = html!(p { b { "pickle" } "barrel" i { "kumquat" } }).into_string();
-    assert_eq!(s, "<p><b>pickle</b>barrel<i>kumquat</i></p>");
+    html_test!(assert_eq: "<p><b>pickle</b>barrel<i>kumquat</i></p>",
+               markup: p { b { "pickle" } "barrel" i { "kumquat" } });
 }
 
 #[test]
 fn nesting_elements() {
-    let s = html!(html body div p sup "butts").into_string();
-    assert_eq!(s, "<html><body><div><p><sup>butts</sup></p></div></body></html>");
+    html_test!(assert_eq: "<html><body><div><p><sup>butts</sup></p></div></body></html>",
+               markup: html body div p sup "butts");
 }
 
 #[test]
 fn empty_elements() {
-    let s = html!("pinkie" br; "pie").into_string();
-    assert_eq!(s, "pinkie<br>pie");
+    html_test!(assert_eq: "pinkie<br>pie",
+               markup: "pinkie" br; "pie");
 }
 
 #[test]
 fn empty_elements_slash() {
-    let s = html!("pinkie" br / "pie").into_string();
-    assert_eq!(s, "pinkie<br>pie");
+    html_test!(assert_eq: "pinkie<br>pie",
+               markup: "pinkie" br / "pie");
 }
 
 #[test]
 fn simple_attributes() {
-    let s = html! {
-        link rel="stylesheet" href="styles.css";
-        section id="midriff" {
-            p class="hotpink" "Hello!"
-        }
-    }.into_string();
-    assert_eq!(s, concat!(
-            r#"<link rel="stylesheet" href="styles.css">"#,
-            r#"<section id="midriff"><p class="hotpink">Hello!</p></section>"#));
+    html_test!(assert_eq:
+               concat!(r#"<link rel="stylesheet" href="styles.css">"#,
+                       r#"<section id="midriff"><p class="hotpink">Hello!</p></section>"#),
+               markup:
+               link rel="stylesheet" href="styles.css";
+               section id="midriff" {
+                   p class="hotpink" "Hello!"
+               });
 }
 
 #[test]
 fn empty_attributes() {
-    let s = html!(div readonly? input type="checkbox" checked?;).into_string();
-    assert_eq!(s, r#"<div readonly><input type="checkbox" checked></div>"#);
+    html_test!(assert_eq: r#"<div readonly><input type="checkbox" checked></div>"#,
+               markup: div readonly? input type="checkbox" checked?;);
 }
 
 #[test]
 fn toggle_empty_attributes() {
-    let rocks = true;
-    let s = html!({
-        input checked?[true];
-        input checked?[false];
-        input checked?[rocks];
-        input checked?[!rocks];
-    }).into_string();
-    assert_eq!(s, concat!(
-            r#"<input checked>"#,
-            r#"<input>"#,
-            r#"<input checked>"#,
-            r#"<input>"#));
+    html_test!(bootstrap: { let rocks = true; },
+               assert_eq:
+               concat!(r#"<input checked>"#,
+                       r#"<input>"#,
+                       r#"<input checked>"#,
+                       r#"<input>"#),
+               markup:
+               input checked?[true];
+               input checked?[false];
+               input checked?[rocks];
+               input checked?[!rocks];
+    );
 }
 
 #[test]
 fn toggle_empty_attributes_braces() {
-    struct Maud { rocks: bool }
-    let s = html!(input checked?[Maud { rocks: true }.rocks] /).into_string();
-    assert_eq!(s, r#"<input checked>"#);
+    html_test!(bootstrap: { struct Maud { rocks: bool } },
+               assert_eq: r#"<input checked>"#,
+               markup: input checked?[Maud { rocks: true }.rocks] /);
 }
 
 #[test]
 fn colons_in_names() {
-    let s = html!(pon-pon:controls-alpha a on:click="yay()" "Yay!").into_string();
-    assert_eq!(s, concat!(
-            r#"<pon-pon:controls-alpha>"#,
-            r#"<a on:click="yay()">Yay!</a>"#,
-            r#"</pon-pon:controls-alpha>"#));
+    html_test!(assert_eq: concat!(r#"<pon-pon:controls-alpha>"#,
+                                  r#"<a on:click="yay()">Yay!</a>"#,
+                                  r#"</pon-pon:controls-alpha>"#),
+               markup: pon-pon:controls-alpha a on:click="yay()" "Yay!");
 }
 
 #[test]
 fn hyphens_in_element_names() {
-    let s = html!(custom-element {}).into_string();
-    assert_eq!(s, "<custom-element></custom-element>");
+    html_test!(assert_eq: "<custom-element></custom-element>",
+               markup: custom-element {});
 }
 
 #[test]
 fn hyphens_in_attribute_names() {
-    let s = html!(this sentence-is="false" of-course? {}).into_string();
-    assert_eq!(s, r#"<this sentence-is="false" of-course></this>"#);
+    html_test!(assert_eq: r#"<this sentence-is="false" of-course></this>"#,
+               markup: this sentence-is="false" of-course? {});
 }
 
 #[test]
 fn class_shorthand() {
-    let s = html!(p { "Hi, " span.name { "Lyra" } "!" }).into_string();
-    assert_eq!(s, r#"<p>Hi, <span class="name">Lyra</span>!</p>"#);
+    html_test!(assert_eq: r#"<p>Hi, <span class="name">Lyra</span>!</p>"#,
+               markup: p { "Hi, " span.name { "Lyra" } "!" });
 }
 
 #[test]
 fn class_shorthand_with_space() {
-    let s = html!(p { "Hi, " span .name { "Lyra" } "!" }).into_string();
-    assert_eq!(s, r#"<p>Hi, <span class="name">Lyra</span>!</p>"#);
+    html_test!(assert_eq: r#"<p>Hi, <span class="name">Lyra</span>!</p>"#,
+               markup: p { "Hi, " span .name { "Lyra" } "!" });
 }
 
 #[test]
 fn classes_shorthand() {
-    let s = html!(p { "Hi, " span.name.here { "Lyra" } "!" }).into_string();
-    assert_eq!(s, r#"<p>Hi, <span class="name here">Lyra</span>!</p>"#);
+    html_test!(assert_eq: r#"<p>Hi, <span class="name here">Lyra</span>!</p>"#,
+               markup: p { "Hi, " span.name.here { "Lyra" } "!" });
 }
 
 #[test]
 fn hyphens_in_class_names() {
-    let s = html!(p.rocks-these.are--my--rocks "yes").into_string();
-    assert_eq!(s, r#"<p class="rocks-these are--my--rocks">yes</p>"#);
+    html_test!(assert_eq: r#"<p class="rocks-these are--my--rocks">yes</p>"#,
+               markup: p.rocks-these.are--my--rocks "yes");
 }
 
 #[test]
 fn toggle_classes() {
-    fn test(is_cupcake: bool, is_muffin: bool) -> Markup {
-        html!(p.cupcake[is_cupcake].muffin[is_muffin] "Testing!")
+    macro_rules! toggle_classes {
+        ($is_cupcake:expr, $is_muffin:expr, $a_eq:expr) => {
+            html_test!(bootstrap: { let is_cupcake = $is_cupcake; let is_muffin = $is_muffin; },
+                       assert_eq: $a_eq,
+                       markup: p.cupcake[is_cupcake].muffin[is_muffin] "Testing!");
+        }
     }
-    assert_eq!(test(true, true).into_string(), r#"<p class="cupcake muffin">Testing!</p>"#);
-    assert_eq!(test(false, true).into_string(), r#"<p class=" muffin">Testing!</p>"#);
-    assert_eq!(test(true, false).into_string(), r#"<p class="cupcake">Testing!</p>"#);
-    assert_eq!(test(false, false).into_string(), r#"<p class="">Testing!</p>"#);
+    toggle_classes!(true, true, r#"<p class="cupcake muffin">Testing!</p>"#);
+    toggle_classes!(false, true, r#"<p class=" muffin">Testing!</p>"#);
+    toggle_classes!(true, false, r#"<p class="cupcake">Testing!</p>"#);
+    toggle_classes!(false, false, r#"<p class="">Testing!</p>"#);
 }
 
 #[test]
 fn toggle_classes_braces() {
-    struct Maud { rocks: bool }
-    let s = html!(p.rocks[Maud { rocks: true }.rocks] "Awesome!").into_string();
-    assert_eq!(s, r#"<p class="rocks">Awesome!</p>"#);
+    html_test!(bootstrap: { struct Maud { rocks: bool } },
+               assert_eq: r#"<p class="rocks">Awesome!</p>"#,
+               markup: p.rocks[Maud { rocks: true }.rocks] "Awesome!");
 }
 
 #[test]
 fn mixed_classes() {
-    fn test(is_muffin: bool) -> Markup {
-        html!(p.cupcake.muffin[is_muffin].lamington "Testing!")
+    macro_rules! mixed_classes{
+        ($is_muffin:expr, $a_eq:expr) => {
+            html_test!(bootstrap: { let is_muffin = $is_muffin; },
+                       assert_eq: $a_eq,
+                       markup:p.cupcake.muffin[is_muffin].lamington "Testing!");
+        }
     }
-    assert_eq!(test(true).into_string(), r#"<p class="cupcake lamington muffin">Testing!</p>"#);
-    assert_eq!(test(false).into_string(), r#"<p class="cupcake lamington">Testing!</p>"#);
+    mixed_classes!(true, r#"<p class="cupcake lamington muffin">Testing!</p>"#);
+    mixed_classes!(false, r#"<p class="cupcake lamington">Testing!</p>"#);
 }
 
 #[test]
 fn ids_shorthand() {
-    let s = html!(p { "Hi, " span#thing { "Lyra" } "!" }).into_string();
-    assert_eq!(s, r#"<p>Hi, <span id="thing">Lyra</span>!</p>"#);
+    html_test!(assert_eq: r#"<p>Hi, <span id="thing">Lyra</span>!</p>"#,
+               markup: p { "Hi, " span#thing { "Lyra" } "!" });
 }
 
 #[test]
 fn classes_attrs_ids_mixed_up() {
-    let s = html!(p { "Hi, " span.name.here lang="en" #thing { "Lyra" } "!" }).into_string();
-    assert_eq!(s, r#"<p>Hi, <span class="name here" id="thing" lang="en">Lyra</span>!</p>"#);
+    html_test!(assert_eq: r#"<p>Hi, <span class="name here" id="thing" lang="en">Lyra</span>!</p>"#,
+               markup: p { "Hi, " span.name.here lang="en" #thing { "Lyra" } "!" });
 }

--- a/maud/tests/control_structures.rs
+++ b/maud/tests/control_structures.rs
@@ -6,166 +6,183 @@
 
 extern crate maud;
 
-use maud::html;
+use maud::{html, html_to};
+
+#[macro_use]
+mod html_test;
 
 #[test]
 fn if_expr() {
-    for (number, &name) in (1..4).zip(["one", "two", "three"].iter()) {
-        let s = html! {
-            @if number == 1 {
-                "one"
-            } @else if number == 2 {
-                "two"
-            } @else if number == 3 {
-                "three"
-            } @else {
-                "oh noes"
-            }
-        }.into_string();
-        assert_eq!(s, name);
-    }
+    html_test!(bootstrap: {
+                   for (number, &name) in
+                       (1..4).zip(["one", "two", "three"].iter())
+               },
+               assert_eq: name,
+               markup:
+               @if number == 1 {
+                   "one"
+               } @else if number == 2 {
+                   "two"
+               } @else if number == 3 {
+                   "three"
+               } @else {
+                   "oh noes"
+               }
+    );
 }
 
 #[test]
 fn if_let() {
-    for &(input, output) in &[(Some("yay"), "yay"), (None, "oh noes")] {
-        let s = html! {
-            @if let Some(value) = input {
-                (value)
-            } @else {
-                "oh noes"
-            }
-        }.into_string();
-        assert_eq!(s, output);
-    }
+    html_test!(bootstrap: {
+                   for &(input, output) in &[(Some("yay"), "yay"),
+                                             (None, "oh noes")]
+               },
+               assert_eq: output,
+               markup:
+               @if let Some(value) = input {
+                   (value)
+               } @else {
+                   "oh noes"
+               }
+    );
 }
 
 #[test]
 fn while_expr() {
-    let mut numbers = (0..3).into_iter().peekable();
-    let s = html! {
-        ul @while numbers.peek().is_some() {
-            li (numbers.next().unwrap())
-        }
-    }.into_string();
-    assert_eq!(s, "<ul><li>0</li><li>1</li><li>2</li></ul>");
+    html_test!(bootstrap: { let mut numbers = (0..3).into_iter().peekable(); },
+               assert_eq: "<ul><li>0</li><li>1</li><li>2</li></ul>",
+               markup:
+               ul @while numbers.peek().is_some() {
+                   li (numbers.next().unwrap())
+               }
+    );
 }
 
 #[test]
 fn while_let_expr() {
-    let mut numbers = (0..3).into_iter();
-    #[cfg_attr(feature = "cargo-clippy", allow(while_let_on_iterator))]
-    let s = html! {
-        ul @while let Some(n) = numbers.next() {
-            li (n)
-        }
-    }.into_string();
-    assert_eq!(s, "<ul><li>0</li><li>1</li><li>2</li></ul>");
+    html_test!(bootstrap: {
+                   let mut numbers = (0..3).into_iter();
+                   #[cfg_attr(feature = "cargo-clippy", allow(while_let_on_iterator))]
+               },
+               assert_eq: "<ul><li>0</li><li>1</li><li>2</li></ul>",
+               markup:
+               ul @while let Some(n) = numbers.next() {
+                   li (n)
+               }
+    );
 }
 
 #[test]
 fn for_expr() {
-    let ponies = ["Apple Bloom", "Scootaloo", "Sweetie Belle"];
-    let s = html! {
-        ul @for pony in &ponies {
-            li (pony)
-        }
-    }.into_string();
-    assert_eq!(s, concat!(
-            "<ul>",
-            "<li>Apple Bloom</li>",
-            "<li>Scootaloo</li>",
-            "<li>Sweetie Belle</li>",
-            "</ul>"));
+    html_test!(bootstrap: { let ponies = ["Apple Bloom", "Scootaloo", "Sweetie Belle"]; },
+               assert_eq: concat!("<ul>",
+                                  "<li>Apple Bloom</li>",
+                                  "<li>Scootaloo</li>",
+                                  "<li>Sweetie Belle</li>",
+                                  "</ul>"),
+               markup:
+               ul @for pony in &ponies {
+                   li (pony)
+               }
+    );
 }
 
 #[test]
 fn match_expr() {
-    for &(input, output) in &[(Some("yay"), "<div>yay</div>"), (None, "oh noes")] {
-        let s = html! {
-            @match input {
-                Some(value) => {
-                    div (value)
-                },
-                None => {
-                    "oh noes"
-                },
-            }
-        }.into_string();
-        assert_eq!(s, output);
-    }
+    html_test!(bootstrap: {
+                   for &(input, output) in &[(Some("yay"), "<div>yay</div>"),
+                                             (None, "oh noes")]
+               },
+               assert_eq: output,
+               markup:
+               @match input {
+                   Some(value) => {
+                       div (value)
+                   },
+                   None => {
+                       "oh noes"
+                   },
+               }
+    );
 }
 
 #[test]
 fn match_expr_without_delims() {
-    for &(input, output) in &[(Some("yay"), "yay"), (None, "<span>oh noes</span>")] {
-        let s = html! {
-            @match input {
-                Some(value) => (value),
-                None => span "oh noes",
-            }
-        }.into_string();
-        assert_eq!(s, output);
-    }
+    html_test!(bootstrap: {
+                   for &(input, output) in &[(Some("yay"), "yay"),
+                                             (None, "<span>oh noes</span>")]
+               },
+               assert_eq: output,
+               markup:
+               @match input {
+                   Some(value) => (value),
+                   None => span "oh noes",
+               }
+    );
 }
 
 #[test]
 fn match_expr_with_guards() {
-    for &(input, output) in &[(Some(1), "one"), (None, "none"), (Some(2), "2")] {
-        let s = html! {
-            @match input {
-                Some(value) if value == 1 => "one",
-                Some(value) => (value),
-                None => "none",
-            }
-        }.into_string();
-        assert_eq!(s, output);
-    }
+    html_test!(bootstrap: {
+                   for &(input, output) in &[(Some(1), "one"),
+                                             (None, "none"),
+                                             (Some(2), "2")]
+               },
+               assert_eq: output,
+               markup:
+               @match input {
+                   Some(value) if value == 1 => "one",
+                   Some(value) => (value),
+                   None => "none",
+               }
+    );
 }
 
 #[test]
 fn match_in_attribute() {
-    for &(input, output) in &[(1, "<span class=\"one\">1</span>"), (2, "<span class=\"two\">2</span>"), (3, "<span class=\"many\">3</span>")] {
-        let s = html! {
+    html_test!(bootstrap: {
+                   for &(input, output) in &[(1, "<span class=\"one\">1</span>"),
+                                             (2, "<span class=\"two\">2</span>"),
+                                             (3, "<span class=\"many\">3</span>")]
+               },
+               assert_eq: output,
+               markup:
             span class=@match input {
                 1 => "one",
                 2 => "two",
                 _ => "many",
             } { (input) }
-        }.into_string();
-        assert_eq!(s, output);
-    }
+    );
 }
 
 #[test]
 fn let_expr() {
-    let s = html! {
-        @let x = 42;
-        "I have " (x) " cupcakes!"
-    }.into_string();
-    assert_eq!(s, "I have 42 cupcakes!");
+    html_test!(assert_eq: "I have 42 cupcakes!",
+               markup:
+               @let x = 42;
+               "I have " (x) " cupcakes!"
+    );
 }
 
 #[test]
 fn let_lexical_scope() {
-    let x = 42;
-    let s = html! {
-        {
-            @let x = 99;
-            "Twilight thought I had " (x) " cupcakes, "
-        }
-        "but I only had " (x) "."
-    }.into_string();
-    assert_eq!(s, concat!(
-            "Twilight thought I had 99 cupcakes, ",
-            "but I only had 42."));
+    html_test!(bootstrap: { let x = 42; },
+               assert_eq: concat!("Twilight thought I had 99 cupcakes, ",
+                                  "but I only had 42."),
+               markup:
+               {
+                   @let x = 99;
+                   "Twilight thought I had " (x) " cupcakes, "
+               }
+               "but I only had " (x) "."
+    );
 }
 
 #[test]
 fn let_type_ascription() {
-    let s = html! {
-        @let mut x: Box<Iterator<Item=u32>> = Box::new(vec![42].into_iter());
-        "I have " (x.next().unwrap()) " cupcakes!"
-    }.into_string();
-    assert_eq!(s, "I have 42 cupcakes!");
+    html_test!(assert_eq: "I have 42 cupcakes!",
+               markup:
+               @let mut x: Box<Iterator<Item=u32>> = Box::new(vec![42].into_iter());
+               "I have " (x.next().unwrap()) " cupcakes!"
+    );
 }

--- a/maud/tests/html_test.rs
+++ b/maud/tests/html_test.rs
@@ -1,0 +1,36 @@
+#[cfg(test)]
+#[macro_export]
+macro_rules! html_test {
+    (bootstrap: { $($bootstrap:tt)* }, assert_eq: $a_eq:expr, markup: $($m:tt)+) => {
+        {
+            $($bootstrap)* {
+                let s = html! { $($m)+ }.into_string();
+                assert_eq!(s, $a_eq, "html!");
+            }
+        }
+
+        {
+            let mut s = String::new();
+            $($bootstrap)* {
+                html_to! { &mut s, $($m)+ };
+                assert_eq!(s, $a_eq, "html_to!, borrowing buffer");
+                s.clear();
+            }
+        }
+
+        {
+            let mut s = String::new();
+            fn to_borrowed_buffer(buffer: &mut String) {
+                $($bootstrap)* {
+                    html_to! { buffer, $($m)+ };
+                    assert_eq!(buffer, $a_eq, "html_to!, buffer already borrowed");
+                    buffer.clear();
+                }
+            }
+            to_borrowed_buffer(&mut s);
+        }
+    };
+    (assert_eq: $a_eq:expr, markup: $($m:tt)+) => {
+        html_test!(bootstrap : {}, assert_eq: $a_eq, markup: $($m)+);
+    };
+}

--- a/maud/tests/splices.rs
+++ b/maud/tests/splices.rs
@@ -5,55 +5,58 @@
 
 extern crate maud;
 
-use maud::html;
+use maud::{html, html_to};
+
+#[macro_use]
+mod html_test;
 
 #[test]
 fn literals() {
-    let s = html!(("<pinkie>")).into_string();
-    assert_eq!(s, "&lt;pinkie&gt;");
+    html_test!(assert_eq: "&lt;pinkie&gt;",
+               markup: ("<pinkie>"));
 }
 
 #[test]
 fn raw_literals() {
-    use maud::PreEscaped;
-    let s = html!((PreEscaped("<pinkie>"))).into_string();
-    assert_eq!(s, "<pinkie>");
+    html_test!(bootstrap: { use maud::PreEscaped; },
+               assert_eq: "<pinkie>",
+               markup: (PreEscaped("<pinkie>")));
 }
 
 #[test]
 fn blocks() {
-    let s = html!({
-        ({
-            let mut result = 1i32;
-            for i in 2..11 {
-                result *= i;
-            }
-            result
-        })
-    }).into_string();
-    assert_eq!(s, "3628800");
+    html_test!(assert_eq: "3628800",
+               markup:
+               ({
+                   let mut result = 1i32;
+                   for i in 2..11 {
+                       result *= i;
+                   }
+                   result
+               })
+    );
 }
 
 #[test]
 fn attributes() {
-    let alt = "Pinkie Pie";
-    let s = html!(img src="pinkie.jpg" alt=(alt) /).into_string();
-    assert_eq!(s, r#"<img src="pinkie.jpg" alt="Pinkie Pie">"#);
+    html_test!(bootstrap: { let alt = "Pinkie Pie"; },
+               assert_eq: r#"<img src="pinkie.jpg" alt="Pinkie Pie">"#,
+               markup: img src="pinkie.jpg" alt=(alt) /);
 }
 
 static BEST_PONY: &'static str = "Pinkie Pie";
 
 #[test]
 fn statics() {
-    let s = html!((BEST_PONY)).into_string();
-    assert_eq!(s, "Pinkie Pie");
+    html_test!(assert_eq: "Pinkie Pie",
+               markup: (BEST_PONY));
 }
 
 #[test]
 fn locals() {
-    let best_pony = "Pinkie Pie";
-    let s = html!((best_pony)).into_string();
-    assert_eq!(s, "Pinkie Pie");
+    html_test!(bootstrap: { let best_pony = "Pinkie Pie"; },
+               assert_eq: "Pinkie Pie",
+               markup: (best_pony));
 }
 
 /// An example struct, for testing purposes only
@@ -73,37 +76,40 @@ impl Creature {
 
 #[test]
 fn structs() {
-    let pinkie = Creature {
-        name: "Pinkie Pie",
-        adorableness: 9,
-    };
-    let s = html!({
-        "Name: " (pinkie.name) ". Rating: " (pinkie.repugnance())
-    }).into_string();
-    assert_eq!(s, "Name: Pinkie Pie. Rating: 1");
+    html_test!(bootstrap: {
+                   let pinkie = Creature {
+                       name: "Pinkie Pie",
+                       adorableness: 9,
+                   };
+               },
+               assert_eq: "Name: Pinkie Pie. Rating: 1",
+               markup:
+               "Name: " (pinkie.name) ". Rating: " (pinkie.repugnance()));
 }
 
 #[test]
 fn tuple_accessors() {
-    let a = ("ducks", "geese");
-    let s = html!((a.0)).into_string();
-    assert_eq!(s, "ducks");
+    html_test!(bootstrap: { let a = ("ducks", "geese"); },
+               assert_eq: "ducks",
+               markup: (a.0));
 }
 
 #[test]
 fn splice_with_path() {
-    mod inner {
-        pub fn name() -> &'static str {
-            "Maud"
-        }
-    }
-    let s = html!((inner::name())).into_string();
-    assert_eq!(s, "Maud");
+    html_test!(bootstrap: {
+                   mod inner {
+                       pub fn name() -> &'static str {
+                           "Maud"
+                       }
+                   }
+               },
+               assert_eq: "Maud",
+               markup: (inner::name()));
 }
 
 #[test]
 fn nested_macro_invocation() {
-    let best_pony = "Pinkie Pie";
-    let s = html!((format!("{} is best pony", best_pony))).into_string();
-    assert_eq!(s, "Pinkie Pie is best pony");
+    html_test!(bootstrap: { let best_pony = "Pinkie Pie"; },
+               assert_eq: "Pinkie Pie is best pony",
+               markup: (format!("{} is best pony", best_pony)));
 }

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -1,26 +1,27 @@
-use proc_macro::{Span, TokenStream, TokenTree};
+use proc_macro::{Span, TokenStream};
 
 use ast::*;
 use build::Builder;
+use parse::{OutputBuffer};
 
-pub fn generate(markups: Vec<Markup>, output_ident: TokenTree) -> TokenStream {
-    let generator = Generator::new(output_ident);
+pub fn generate(markups: Vec<Markup>, output_buffer: OutputBuffer) -> TokenStream {
+    let generator = Generator::new(output_buffer);
     let mut builder = generator.builder();
     generator.markups(markups, &mut builder);
     builder.build()
 }
 
 struct Generator {
-    output_ident: TokenTree,
+    output_buffer: OutputBuffer,
 }
 
 impl Generator {
-    fn new(output_ident: TokenTree) -> Generator {
-        Generator { output_ident }
+    fn new(output_buffer: OutputBuffer) -> Generator {
+        Generator { output_buffer }
     }
 
     fn builder(&self) -> Builder {
-        Builder::new(self.output_ident.clone())
+        Builder::new(self.output_buffer.clone())
     }
 
     fn markups(&self, markups: Vec<Markup>, builder: &mut Builder) {


### PR DESCRIPTION
Hi, this PR targets the feature requested in #90 

It's based on your current work in the `better-lints` branch.

It's now possible to write:
```rust
struct Css(&'static str);

impl Render for Css {
    fn render_to(&self, buffer: &mut String) {
        // With a mutable reference
        html_to! { buffer,
            link rel="stylesheet" type="text/css" href=(self.0);
        }
    }
}

fn main() {
    let mut s = String::with_capacity(100);

    // With the owned string in scope
    html_to!{ &mut s,
        (DOCTYPE)
        html {
            head (Css("style.css"))
            //…
        }
    };
    println!("{}", s);
}
```

All tests were rewritten to use html_test! instead of html! (a wrapper to test against html! and html_to! with its two forms)

Please tell me if you see anything I should change, like moving the new functions in their own file etc, I wasn't sure if it was the right place to put them.