### PR TITLE
Upgrade syn to 1.0.8. Upgrade matches to 0.1.8

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -376,7 +376,7 @@ version = "0.21.0"
 dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maud_htmlescape 0.17.0",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -11,8 +11,8 @@ description = "Compile-time HTML templates."
 edition = "2018"
 
 [dependencies]
-syn = "0.15.34"
-matches = "0.1.6"
+syn = "1.0.8"
+matches = "0.1.8"
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 
 [lib]


### PR DESCRIPTION
Closes #178 

Not much needed to be done? I ran cargo test and all the tests passed, so I think that it's fine. Not entirely sure if that was all that needed to be done, however.