### PR TITLE
actix-web >= 2.0.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+- [Changed] Update Actix to 2.0.0. Actix 1.0.0 is no longer supported.
+  [#182](https://github.com/lambda-fairy/maud/pull/182)
 
 ## [0.21.0] - 2019-07-01
 

--- a/docs/content/web-frameworks.md
+++ b/docs/content/web-frameworks.md
@@ -9,7 +9,7 @@ Maud includes support for these web frameworks: [Actix], [Iron], [Rocket], and [
 
 # Actix
 
-Actix support is available with the "actix-web" feature:
+Actix support is available with the "actix-web" or the "actix-web-2" feature. The "actix-web" feature enables usage of 1.0.0 <= actix-web < 2.0.0 wheras "actix-web-2" enables the usage of version 2.:
 
 ```toml
 # ...

--- a/docs/content/web-frameworks.md
+++ b/docs/content/web-frameworks.md
@@ -9,7 +9,7 @@ Maud includes support for these web frameworks: [Actix], [Iron], [Rocket], and [
 
 # Actix
 
-Actix support is available with the "actix-web" or the "actix-web-2" feature. The "actix-web" feature enables usage of 1.0.0 <= actix-web < 2.0.0 wheras "actix-web-2" enables the usage of version 2.:
+Actix support is available with the "actix-web" feature:
 
 ```toml
 # ...

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -12,16 +12,15 @@ categories = ["template-engine"]
 edition = "2018"
 
 [features]
-actix-web-2 = ["actix-web-2-dep", "futures"]
+actix-web = ["actix-web-dep", "futures"]
 
 [dependencies]
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 maud_macros = { version = "0.21.0", path = "../maud_macros" }
 iron = { version = ">= 0.5.1, < 0.7.0", optional = true }
 rocket = { version = ">= 0.3, < 0.5", optional = true }
-actix-web = { version = "1.0.0", optional = true, default-features = false }
-actix-web-2-dep = { version = "2.0.0", optional = true, default-features = false, package = "actix-web" }
 futures = { version = "0.3.0", optional = true }
+actix-web-dep = { version = "2.0.0", optional = true, default-features = false, package = "actix-web" }
 
 [dev-dependencies]
 compiletest_rs = { version = "0.3.19", features = ["stable"] }

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -11,12 +11,17 @@ description = "Compile-time HTML templates."
 categories = ["template-engine"]
 edition = "2018"
 
+[features]
+actix-web-2 = ["actix-web-2-dep", "futures"]
+
 [dependencies]
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 maud_macros = { version = "0.21.0", path = "../maud_macros" }
 iron = { version = ">= 0.5.1, < 0.7.0", optional = true }
 rocket = { version = ">= 0.3, < 0.5", optional = true }
 actix-web = { version = "1.0.0", optional = true, default-features = false }
+actix-web-2-dep = { version = "2.0.0", optional = true, default-features = false, package = "actix-web" }
+futures = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 compiletest_rs = { version = "0.3.19", features = ["stable"] }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -9,7 +9,7 @@
 
 #![doc(html_root_url = "https://docs.rs/maud/0.21.0")]
 
-#[cfg(feature = "actix-web")] extern crate actix_web;
+#[cfg(feature = "actix-web")] extern crate actix_web_dep;
 #[cfg(feature = "iron")] extern crate iron;
 #[cfg(feature = "rocket")] extern crate rocket;
 
@@ -194,23 +194,7 @@ mod rocket_support {
 #[cfg(feature = "actix-web")]
 mod actix_support {
     use crate::PreEscaped;
-    use actix_web::{Responder, HttpResponse, HttpRequest, Error};
-
-    impl Responder for PreEscaped<String> {
-        type Error = Error;
-        type Future = Result<HttpResponse, Self::Error>;
-        fn respond_to(self, _req: &HttpRequest) -> Self::Future {
-            Ok(HttpResponse::Ok()
-               .content_type("text/html; charset=utf-8")
-               .body(self.0))
-        }
-    }
-}
-
-#[cfg(feature = "actix-web-2")]
-mod actix2_support {
-    use crate::PreEscaped;
-    use actix_web_2_dep::{Responder, HttpResponse, HttpRequest, Error};
+    use actix_web_dep::{Responder, HttpResponse, HttpRequest, Error};
     use futures::future::{ok, Ready};
 
     impl Responder for PreEscaped<String> {

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -206,3 +206,20 @@ mod actix_support {
         }
     }
 }
+
+#[cfg(feature = "actix-web-2")]
+mod actix2_support {
+    use crate::PreEscaped;
+    use actix_web_2_dep::{Responder, HttpResponse, HttpRequest, Error};
+    use futures::future::{ok, Ready};
+
+    impl Responder for PreEscaped<String> {
+        type Error = Error;
+        type Future = Ready<Result<HttpResponse, Self::Error>>;
+        fn respond_to(self, _req: &HttpRequest) -> Self::Future {
+            ok(HttpResponse::Ok()
+               .content_type("text/html; charset=utf-8")
+               .body(self.0))
+        }
+    }
+}


### PR DESCRIPTION
Cheers,

With the advent of async, actix-web started using futures in their APIs and traits, unfortunately resulting in breaking changes within the Responder trait which maud implements.

I have added support for the newest version of actix-web while trying to still support version 1, since most users have probably not yet migrated to the newest version.

In order to do so I added the trait `actix-web-2` feature and the `actix-web-2-dep` dependency in order to avoid name clashes. Unfortunately enabling the feature also depends on the `futures` crate, since it is used to implement the Responder trait. I also mentioned said support in the web-framework documentation. I have not added any tests, since there were no actix-web tests I could modify. I have verified that this change works within my own project though.

Note that `futures` dependency may not necessarily be required. It was used within actix-web itself to implement the Responder traits, but I could not trivially verify that it is strictly required to use that crate and not some other implementation.

P.S. Thanks for your awesome crate!