### PR TITLE
Silence "specialization is incomplete" warning

### DIFF
--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(specialization)]
+#![feature(min_specialization)]
 
 //! A macro for writing HTML templates.
 //!


### PR DESCRIPTION
See rust-lang/rust#71420.

This doesn't need a release (or a changelog entry) as it just fixes a warning.