### PR TITLE
Switch to 3rd party `quote` macro

### DIFF
--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -14,6 +14,8 @@ edition = "2018"
 syn = "1.0.8"
 matches = "0.1.8"
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
+quote = "1.0.7"
+proc-macro2 = "1.0.18"
 
 [lib]
 name = "maud_macros"

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -82,18 +82,16 @@ impl Generator {
 
     fn splice(&self, expr: TokenStream) -> TokenStream {
         let output_ident = self.output_ident.clone();
-        TokenStream::from(
-            quote!({
-                // Create a local trait alias so that autoref works
-                trait Render: maud::Render {
-                    fn __maud_render_to(&self, output_ident: &mut ::std::string::String) {
-                        maud::Render::render_to(self, output_ident);
-                    }
+        quote!({
+            // Create a local trait alias so that autoref works
+            trait Render: maud::Render {
+                fn __maud_render_to(&self, output_ident: &mut ::std::string::String) {
+                    maud::Render::render_to(self, output_ident);
                 }
-                impl<T: maud::Render> Render for T {}
-                #expr.__maud_render_to(&mut #output_ident);
-            })
-        )
+            }
+            impl<T: maud::Render> Render for T {}
+            #expr.__maud_render_to(&mut #output_ident);
+        })
     }
 
     fn element(
@@ -141,7 +139,7 @@ impl Generator {
                         build.push_str(" ");
                         self.name(name.into(), &mut build);
                         let body = build.finish();
-                        TokenStream::from(quote!(#head { #body }))
+                        quote!(#head { #body })
                     })
                 },
             }
@@ -245,7 +243,7 @@ fn desugar_toggler(Toggler { cond, cond_span }: Toggler) -> TokenStream {
         wrapped_cond.set_span(cond_span.into());
         cond = TokenStream::from(wrapped_cond);
     }
-    TokenStream::from(quote!(if #cond))
+    quote!(if #cond)
 }
 
 ////////////////////////////////////////////////////////
@@ -286,7 +284,7 @@ impl Builder {
         let push_str_expr = {
             let output_ident = self.output_ident.clone();
             let string = TokenTree::Literal(Literal::string(&self.tail));
-            TokenStream::from(quote!(#output_ident.push_str(#string);))
+            quote!(#output_ident.push_str(#string);)
         };
         self.tail.clear();
         self.tokens.extend(push_str_expr);

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -1,15 +1,15 @@
 use matches::matches;
 use maud_htmlescape::Escaper;
-use proc_macro::{
+use proc_macro2::{
     Delimiter,
     Group,
     Literal,
-    quote,
     Span,
     Ident,
     TokenStream,
     TokenTree,
 };
+use quote::quote;
 
 use crate::ast::*;
 
@@ -48,10 +48,10 @@ impl Generator {
                 }
             },
             Markup::Literal { content, .. } => build.push_escaped(&content),
-            Markup::Symbol { symbol } => self.name(symbol, build),
-            Markup::Splice { expr, .. } => build.push_tokens(self.splice(expr)),
-            Markup::Element { name, attrs, body } => self.element(name, attrs, body, build),
-            Markup::Let { tokens, .. } => build.push_tokens(tokens),
+            Markup::Symbol { symbol } => self.name(symbol.into(), build),
+            Markup::Splice { expr, .. } => build.push_tokens(self.splice(expr.into())),
+            Markup::Element { name, attrs, body } => self.element(name.into(), attrs, body, build),
+            Markup::Let { tokens, .. } => build.push_tokens(TokenStream::from(tokens)),
             Markup::Special { segments } => {
                 for segment in segments {
                     build.push_tokens(self.special(segment));
@@ -64,8 +64,9 @@ impl Generator {
                         .map(|arm| self.match_arm(arm))
                         .collect();
                     let mut body = TokenTree::Group(Group::new(Delimiter::Brace, body));
-                    body.set_span(arms_span);
-                    quote!($head $body)
+                    body.set_span(arms_span.into());
+                    let head: TokenStream = head.into();
+                    quote!(#head #body)
                 });
             },
         }
@@ -75,22 +76,24 @@ impl Generator {
         let mut build = self.builder();
         self.markups(markups, &mut build);
         let mut block = TokenTree::Group(Group::new(Delimiter::Brace, build.finish()));
-        block.set_span(outer_span);
+        block.set_span(outer_span.into());
         TokenStream::from(block)
     }
 
     fn splice(&self, expr: TokenStream) -> TokenStream {
         let output_ident = self.output_ident.clone();
-        quote!({
-            // Create a local trait alias so that autoref works
-            trait Render: maud::Render {
-                fn __maud_render_to(&self, output_ident: &mut ::std::string::String) {
-                    maud::Render::render_to(self, output_ident);
+        TokenStream::from(
+            quote!({
+                // Create a local trait alias so that autoref works
+                trait Render: maud::Render {
+                    fn __maud_render_to(&self, output_ident: &mut ::std::string::String) {
+                        maud::Render::render_to(self, output_ident);
+                    }
                 }
-            }
-            impl<T: maud::Render> Render for T {}
-            $expr.__maud_render_to(&mut $output_ident);
-        })
+                impl<T: maud::Render> Render for T {}
+                #expr.__maud_render_to(&mut #output_ident);
+            })
+        )
     }
 
     fn element(
@@ -122,23 +125,23 @@ impl Generator {
             match attr_type {
                 AttrType::Normal { value } => {
                     build.push_str(" ");
-                    self.name(name, build);
+                    self.name(name.into(), build);
                     build.push_str("=\"");
                     self.markup(value, build);
                     build.push_str("\"");
                 },
                 AttrType::Empty { toggler: None } => {
                     build.push_str(" ");
-                    self.name(name, build);
+                    self.name(name.into(), build);
                 },
                 AttrType::Empty { toggler: Some(toggler) } => {
                     let head = desugar_toggler(toggler);
                     build.push_tokens({
                         let mut build = self.builder();
                         build.push_str(" ");
-                        self.name(name, &mut build);
+                        self.name(name.into(), &mut build);
                         let body = build.finish();
-                        quote!($head { $body })
+                        TokenStream::from(quote!(#head { #body }))
                     })
                 },
             }
@@ -147,12 +150,14 @@ impl Generator {
 
     fn special(&self, Special { head, body, .. }: Special) -> TokenStream {
         let body = self.block(body);
-        quote!($head $body)
+        let head: TokenStream = head.into();
+        quote!(#head #body)
     }
 
     fn match_arm(&self, MatchArm { head, body }: MatchArm) -> TokenStream {
         let body = self.block(body);
-        quote!($head $body)
+        let head: TokenStream = head.into();
+        quote!(#head #body)
     }
 }
 
@@ -201,15 +206,15 @@ fn desugar_classes_or_ids(
         };
         let head = desugar_toggler(toggler);
         markups.push(Markup::Special {
-            segments: vec![Special { at_span: Span::call_site(), head, body }],
+            segments: vec![Special { at_span: proc_macro::Span::call_site(), head: head.into(), body }],
         });
     }
     Some(Attribute {
-        name: TokenStream::from(TokenTree::Ident(Ident::new(attr_name, Span::call_site()))),
+        name: TokenStream::from(TokenTree::Ident(Ident::new(attr_name, Span::call_site()))).into(),
         attr_type: AttrType::Normal {
             value: Markup::Block(Block {
                 markups,
-                outer_span: Span::call_site(),
+                outer_span: proc_macro::Span::call_site(),
             }),
         },
     })
@@ -228,18 +233,19 @@ fn prepend_leading_space(name: Markup, leading_space: &mut bool) -> Vec<Markup> 
     markups
 }
 
-fn desugar_toggler(Toggler { mut cond, cond_span }: Toggler) -> TokenStream {
+fn desugar_toggler(Toggler { cond, cond_span }: Toggler) -> TokenStream {
     // If the expression contains an opening brace `{`,
     // wrap it in parentheses to avoid parse errors
+    let mut cond = TokenStream::from(cond);
     if cond.clone().into_iter().any(|token| match token {
         TokenTree::Group(ref group) if group.delimiter() == Delimiter::Brace => true,
         _ => false,
     }) {
         let mut wrapped_cond = TokenTree::Group(Group::new(Delimiter::Parenthesis, cond));
-        wrapped_cond.set_span(cond_span);
+        wrapped_cond.set_span(cond_span.into());
         cond = TokenStream::from(wrapped_cond);
     }
-    quote!(if $cond)
+    TokenStream::from(quote!(if #cond))
 }
 
 ////////////////////////////////////////////////////////
@@ -280,7 +286,7 @@ impl Builder {
         let push_str_expr = {
             let output_ident = self.output_ident.clone();
             let string = TokenTree::Literal(Literal::string(&self.tail));
-            quote!($output_ident.push_str($string);)
+            TokenStream::from(quote!(#output_ident.push_str(#string);))
         };
         self.tail.clear();
         self.tokens.extend(push_str_expr);

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -232,9 +232,9 @@ fn prepend_leading_space(name: Markup, leading_space: &mut bool) -> Vec<Markup> 
 }
 
 fn desugar_toggler(Toggler { cond, cond_span }: Toggler) -> TokenStream {
+    let mut cond = TokenStream::from(cond);
     // If the expression contains an opening brace `{`,
     // wrap it in parentheses to avoid parse errors
-    let mut cond = TokenStream::from(cond);
     if cond.clone().into_iter().any(|token| match token {
         TokenTree::Group(ref group) if group.delimiter() == Delimiter::Brace => true,
         _ => false,

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -51,7 +51,7 @@ impl Generator {
             Markup::Symbol { symbol } => self.name(symbol.into(), build),
             Markup::Splice { expr, .. } => build.push_tokens(self.splice(expr.into())),
             Markup::Element { name, attrs, body } => self.element(name.into(), attrs, body, build),
-            Markup::Let { tokens, .. } => build.push_tokens(TokenStream::from(tokens)),
+            Markup::Let { tokens, .. } => build.push_tokens(tokens.into()),
             Markup::Special { segments } => {
                 for segment in segments {
                     build.push_tokens(self.special(segment));
@@ -272,7 +272,7 @@ impl Builder {
         Escaper::new(&mut self.tail).write_str(string).unwrap();
     }
 
-    fn push_tokens<T: IntoIterator<Item=TokenTree>>(&mut self, tokens: T) {
+    fn push_tokens(&mut self, tokens: TokenStream) {
         self.cut();
         self.tokens.extend(tokens);
     }

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -39,7 +39,7 @@ fn expand(input: TokenStream) -> TokenStream {
     // code size of the template itself
     let size_hint = input.to_string().len();
     let size_hint = TokenTree::Literal(Literal::u64_unsuffixed(size_hint as u64));
-    let markups = match parse::parse(proc_macro::TokenStream::from(input)) {
+    let markups = match parse::parse(input.into()) {
         Ok(markups) => markups,
         Err(()) => Vec::new(),
     };

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -45,12 +45,10 @@ fn expand(input: TokenStream) -> TokenStream {
         Err(()) => Vec::new(),
     };
     let stmts = generate::generate(markups, output_ident.clone());
-    TokenStream::from(
-        quote!({
-            extern crate maud;
-            let mut #output_ident = ::std::string::String::with_capacity(#size_hint);
-            #stmts
-            maud::PreEscaped(#output_ident)
-        })
-    )
+    quote!({
+        extern crate maud;
+        let mut #output_ident = ::std::string::String::with_capacity(#size_hint);
+        #stmts
+        maud::PreEscaped(#output_ident)
+    })
 }

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -33,7 +33,7 @@ pub fn html_debug(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 }
 
 fn expand(input: TokenStream) -> TokenStream {
-    // using proc_macro::Span here allows us to work around the limitation set by proc_macro2 on Span
+    // TODO: call `proc_macro2::Span::mixed_site()` directly when Rust 1.45 is stable
     let output_ident = TokenTree::Ident(Ident::new("__maud_output", proc_macro::Span::mixed_site().into()));
     // Heuristic: the size of the resulting markup tends to correlate with the
     // code size of the template itself

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -16,7 +16,6 @@ mod generate;
 mod parse;
 
 use proc_macro2::{Literal, Ident, TokenStream, TokenTree};
-// use proc_macro::quote;
 use quote::quote;
 
 type ParseResult<T> = Result<T, ()>;


### PR DESCRIPTION
This mostly implements lambda-fairy/maud#191.

In general this is done (it builds, tests pass).

To give an overview of the changes:
All internal types are now using `proc_macro2` instead of `proc_macro` **except** [ast.rs](https://github.com/lambda-fairy/maud/blob/master/maud_macros/src/ast.rs) and [parse.rs](https://github.com/lambda-fairy/maud/blob/master/maud_macros/src/parse.rs) as they make heavy use of the location information of spans, which `proc_macro2::Span` cannot provide (yet).
I did it this way, as this avoids excessive conversions between the 2 crates. As the api surface is (mostly) the same i think this will be fine.

I tried to keep actual type-conversions between `proc_macro` and `proc_macro2` to a minimum.

@lambda-fairy if you also could just look over the PR again style wise, before i start resolving the merge conflicts i would be thankfull.