### PR TITLE
Use `std::matches!`

### DIFF
--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -360,11 +360,6 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "matches"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "maud"
 version = "0.22.0"
 dependencies = [
@@ -380,8 +375,9 @@ version = "0.17.0"
 name = "maud_macros"
 version = "0.22.0"
 dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maud_htmlescape 0.17.0",
+ "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -859,7 +855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum liquid-lib 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c4aa47dc08fd8c6c8aea70a0da2a98c0f0416d49e8b03c5c46354ef559bee3c"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 "checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 
 [dependencies]
 syn = "1.0.8"
-matches = "0.1.8"
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 quote = "1.0.7"
 proc-macro2 = "1.0.18"

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -1,4 +1,3 @@
-use matches::matches;
 use maud_htmlescape::Escaper;
 use proc_macro2::{
     Delimiter,
@@ -235,9 +234,8 @@ fn desugar_toggler(Toggler { cond, cond_span }: Toggler) -> TokenStream {
     let mut cond = TokenStream::from(cond);
     // If the expression contains an opening brace `{`,
     // wrap it in parentheses to avoid parse errors
-    if cond.clone().into_iter().any(|token| match token {
-        TokenTree::Group(ref group) if group.delimiter() == Delimiter::Brace => true,
-        _ => false,
+    if cond.clone().into_iter().any(|token| {
+        matches!(token, TokenTree::Group(ref group) if group.delimiter() == Delimiter::Brace)
     }) {
         let mut wrapped_cond = TokenTree::Group(Group::new(Delimiter::Parenthesis, cond));
         wrapped_cond.set_span(cond_span.into());

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -234,14 +234,16 @@ fn desugar_toggler(Toggler { cond, cond_span }: Toggler) -> TokenStream {
     let mut cond = TokenStream::from(cond);
     // If the expression contains an opening brace `{`,
     // wrap it in parentheses to avoid parse errors
-    if cond.clone().into_iter().any(|token| {
-        matches!(token, TokenTree::Group(ref group) if group.delimiter() == Delimiter::Brace)
-    }) {
+    if cond.clone().into_iter().any(is_braced_block) {
         let mut wrapped_cond = TokenTree::Group(Group::new(Delimiter::Parenthesis, cond));
         wrapped_cond.set_span(cond_span.into());
         cond = TokenStream::from(wrapped_cond);
     }
     quote!(if #cond)
+}
+
+fn is_braced_block(token: TokenTree) -> bool {
+    matches!(token, TokenTree::Group(ref group) if group.delimiter() == Delimiter::Brace)
 }
 
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
- Remove crates.io `matches` in favor of the `std` version

- Fix Clippy warning by changing a `match ... { ... }` to `matches!(...)`