### PR TITLE
Switch to version_check

### DIFF
--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -26,7 +26,7 @@ futures = { version = "0.3.0", optional = true }
 actix-web-dep = { version = "2.0.0", optional = true, default-features = false, package = "actix-web" }
 
 [build-dependencies]
-rustc_version = "0.2.3"
+version_check = "0.9.2"
 
 [dev-dependencies]
 trybuild = { version = "1.0.33", features = ["diff"] }

--- a/maud/build.rs
+++ b/maud/build.rs
@@ -1,8 +1,7 @@
-use rustc_version::{version_meta, Channel};
+use version_check;
 
 fn main() {
-    match version_meta().map(|v| v.channel).unwrap_or(Channel::Stable) {
-        Channel::Dev | Channel::Nightly => println!("cargo:rustc-cfg=unstable"),
-        Channel::Beta | Channel::Stable => {}
+    if version_check::is_feature_flaggable() == Some(true) {
+        println!("cargo:rustc-cfg=unstable");
     }
 }

--- a/maud/build.rs
+++ b/maud/build.rs
@@ -1,5 +1,3 @@
-use version_check;
-
 fn main() {
     if version_check::is_feature_flaggable() == Some(true) {
         println!("cargo:rustc-cfg=unstable");


### PR DESCRIPTION
version_check has fewer dependencies, and is already used by proc-macro-error and Rocket.