### PR TITLE
Only deploy documentation when a release is tagged

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
         local_dir: docs/site
         keep_history: false
         on:
-          branch: master
+          tags: true
     - name: "Format"
       before_script:
         - rustup component add rustfmt


### PR DESCRIPTION
I would expect that most people reading the docs are using the crates.io version, not trunk.