### PR TITLE
Enable LXD for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust: nightly
+virt: lxd
 
 jobs:
   include:


### PR DESCRIPTION
It seems a lot faster – the "All features" build is ~ 1:45 instead of ~ 3:15.