### PR TITLE
Clean up tests

### DIFF
--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -2,71 +2,71 @@ use maud::{html, Markup};
 
 #[test]
 fn literals() {
-    let s = html!("du\tcks" "-23" "3.14\n" "geese").into_string();
-    assert_eq!(s, "du\tcks-233.14\ngeese");
+    let result = html! { "du\tcks" "-23" "3.14\n" "geese" };
+    assert_eq!(result.into_string(), "du\tcks-233.14\ngeese");
 }
 
 #[test]
 fn escaping() {
-    let s = html!("<flim&flam>").into_string();
-    assert_eq!(s, "&lt;flim&amp;flam&gt;");
+    let result = html! { "<flim&flam>" };
+    assert_eq!(result.into_string(), "&lt;flim&amp;flam&gt;");
 }
 
 #[test]
 fn semicolons() {
-    let s = html! {
+    let result = html! {
         "one";
         "two";
         "three";
         ;;;;;;;;;;;;;;;;;;;;;;;;
         "four";
-    }
-    .into_string();
-    assert_eq!(s, "onetwothreefour");
+    };
+    assert_eq!(result.into_string(), "onetwothreefour");
 }
 
 #[test]
 fn blocks() {
-    let s = html! {
+    let result = html! {
         "hello"
         {
             " ducks" " geese"
         }
         " swans"
-    }
-    .into_string();
-    assert_eq!(s, "hello ducks geese swans");
+    };
+    assert_eq!(result.into_string(), "hello ducks geese swans");
 }
 
 #[test]
 fn simple_elements() {
-    let s = html!(p { b { "pickle" } "barrel" i { "kumquat" } }).into_string();
-    assert_eq!(s, "<p><b>pickle</b>barrel<i>kumquat</i></p>");
+    let result = html! { p { b { "pickle" } "barrel" i { "kumquat" } } };
+    assert_eq!(
+        result.into_string(),
+        "<p><b>pickle</b>barrel<i>kumquat</i></p>"
+    );
 }
 
 #[test]
 fn empty_elements() {
-    let s = html!("pinkie" br; "pie").into_string();
-    assert_eq!(s, "pinkie<br>pie");
+    let result = html! { "pinkie" br; "pie" };
+    assert_eq!(result.into_string(), "pinkie<br>pie");
 }
 
 #[test]
 fn empty_elements_slash() {
-    let s = html!("pinkie" br / "pie").into_string();
-    assert_eq!(s, "pinkie<br>pie");
+    let result = html! { "pinkie" br / "pie" };
+    assert_eq!(result.into_string(), "pinkie<br>pie");
 }
 
 #[test]
 fn simple_attributes() {
-    let s = html! {
+    let result = html! {
         link rel="stylesheet" href="styles.css";
         section id="midriff" {
             p class="hotpink" { "Hello!" }
         }
-    }
-    .into_string();
+    };
     assert_eq!(
-        s,
+        result.into_string(),
         concat!(
             r#"<link rel="stylesheet" href="styles.css">"#,
             r#"<section id="midriff"><p class="hotpink">Hello!</p></section>"#
@@ -76,22 +76,24 @@ fn simple_attributes() {
 
 #[test]
 fn empty_attributes() {
-    let s = html!(div readonly? { input type="checkbox" checked?; }).into_string();
-    assert_eq!(s, r#"<div readonly><input type="checkbox" checked></div>"#);
+    let result = html! { div readonly? { input type="checkbox" checked?; } };
+    assert_eq!(
+        result.into_string(),
+        r#"<div readonly><input type="checkbox" checked></div>"#
+    );
 }
 
 #[test]
 fn toggle_empty_attributes() {
     let rocks = true;
-    let s = html!({
+    let result = html! {
         input checked?[true];
         input checked?[false];
         input checked?[rocks];
         input checked?[!rocks];
-    })
-    .into_string();
+    };
     assert_eq!(
-        s,
+        result.into_string(),
         concat!(
             r#"<input checked>"#,
             r#"<input>"#,
@@ -106,15 +108,15 @@ fn toggle_empty_attributes_braces() {
     struct Maud {
         rocks: bool,
     }
-    let s = html!(input checked?[Maud { rocks: true }.rocks] /).into_string();
-    assert_eq!(s, r#"<input checked>"#);
+    let result = html! { input checked?[Maud { rocks: true }.rocks]; };
+    assert_eq!(result.into_string(), r#"<input checked>"#);
 }
 
 #[test]
 fn colons_in_names() {
-    let s = html!(pon-pon:controls-alpha { a on:click="yay()" { "Yay!" } }).into_string();
+    let result = html! { pon-pon:controls-alpha { a on:click="yay()" { "Yay!" } } };
     assert_eq!(
-        s,
+        result.into_string(),
         concat!(
             r#"<pon-pon:controls-alpha>"#,
             r#"<a on:click="yay()">Yay!</a>"#,
@@ -123,47 +125,64 @@ fn colons_in_names() {
     );
 }
 
-#[rustfmt::skip::macros(html)]
 #[test]
 fn hyphens_in_element_names() {
-    let s = html!(custom-element {}).into_string();
-    assert_eq!(s, "<custom-element></custom-element>");
+    let result = html! { custom-element {} };
+    assert_eq!(result.into_string(), "<custom-element></custom-element>");
 }
 
 #[test]
 fn hyphens_in_attribute_names() {
-    let s = html!(this sentence-is="false" of-course? {}).into_string();
-    assert_eq!(s, r#"<this sentence-is="false" of-course></this>"#);
+    let result = html! { this sentence-is="false" of-course? {} };
+    assert_eq!(
+        result.into_string(),
+        r#"<this sentence-is="false" of-course></this>"#
+    );
 }
 
 #[test]
 fn class_shorthand() {
-    let s = html!(p { "Hi, " span.name { "Lyra" } "!" }).into_string();
-    assert_eq!(s, r#"<p>Hi, <span class="name">Lyra</span>!</p>"#);
+    let result = html! { p { "Hi, " span.name { "Lyra" } "!" } };
+    assert_eq!(
+        result.into_string(),
+        r#"<p>Hi, <span class="name">Lyra</span>!</p>"#
+    );
 }
 
 #[test]
 fn class_shorthand_with_space() {
-    let s = html!(p { "Hi, " span .name { "Lyra" } "!" }).into_string();
-    assert_eq!(s, r#"<p>Hi, <span class="name">Lyra</span>!</p>"#);
+    let result = html! { p { "Hi, " span .name { "Lyra" } "!" } };
+    assert_eq!(
+        result.into_string(),
+        r#"<p>Hi, <span class="name">Lyra</span>!</p>"#
+    );
 }
 
 #[test]
 fn classes_shorthand() {
-    let s = html!(p { "Hi, " span.name.here { "Lyra" } "!" }).into_string();
-    assert_eq!(s, r#"<p>Hi, <span class="name here">Lyra</span>!</p>"#);
+    let result = html! { p { "Hi, " span.name.here { "Lyra" } "!" } };
+    assert_eq!(
+        result.into_string(),
+        r#"<p>Hi, <span class="name here">Lyra</span>!</p>"#
+    );
 }
 
 #[test]
 fn hyphens_in_class_names() {
-    let s = html!(p.rocks-these.are--my--rocks { "yes" }).into_string();
-    assert_eq!(s, r#"<p class="rocks-these are--my--rocks">yes</p>"#);
+    let result = html! { p.rocks-these.are--my--rocks { "yes" } };
+    assert_eq!(
+        result.into_string(),
+        r#"<p class="rocks-these are--my--rocks">yes</p>"#
+    );
 }
 
 #[test]
 fn class_string() {
-    let s = html!(h1."pinkie-123" { "Pinkie Pie" }).into_string();
-    assert_eq!(s, r#"<h1 class="pinkie-123">Pinkie Pie</h1>"#);
+    let result = html! { h1."pinkie-123" { "Pinkie Pie" } };
+    assert_eq!(
+        result.into_string(),
+        r#"<h1 class="pinkie-123">Pinkie Pie</h1>"#
+    );
 }
 
 #[test]
@@ -194,16 +213,16 @@ fn toggle_classes_braces() {
     struct Maud {
         rocks: bool,
     }
-    let s = html!(p.rocks[Maud { rocks: true }.rocks] { "Awesome!" }).into_string();
-    assert_eq!(s, r#"<p class="rocks">Awesome!</p>"#);
+    let result = html! { p.rocks[Maud { rocks: true }.rocks] { "Awesome!" } };
+    assert_eq!(result.into_string(), r#"<p class="rocks">Awesome!</p>"#);
 }
 
 #[test]
 fn toggle_classes_string() {
     let is_cupcake = true;
     let is_muffin = false;
-    let s = html!(p."cupcake"[is_cupcake]."is_muffin"[is_muffin] { "Testing!" }).into_string();
-    assert_eq!(s, r#"<p class="cupcake">Testing!</p>"#);
+    let result = html! { p."cupcake"[is_cupcake]."is_muffin"[is_muffin] { "Testing!" } };
+    assert_eq!(result.into_string(), r#"<p class="cupcake">Testing!</p>"#);
 }
 
 #[test]
@@ -223,51 +242,57 @@ fn mixed_classes() {
 
 #[test]
 fn id_shorthand() {
-    let s = html!(p { "Hi, " span#thing { "Lyra" } "!" }).into_string();
-    assert_eq!(s, r#"<p>Hi, <span id="thing">Lyra</span>!</p>"#);
+    let result = html! { p { "Hi, " span#thing { "Lyra" } "!" } };
+    assert_eq!(
+        result.into_string(),
+        r#"<p>Hi, <span id="thing">Lyra</span>!</p>"#
+    );
 }
 
 #[test]
 fn id_string() {
-    let s = html!(h1#"pinkie-123" { "Pinkie Pie" }).into_string();
-    assert_eq!(s, r#"<h1 id="pinkie-123">Pinkie Pie</h1>"#);
+    let result = html! { h1#"pinkie-123" { "Pinkie Pie" } };
+    assert_eq!(
+        result.into_string(),
+        r#"<h1 id="pinkie-123">Pinkie Pie</h1>"#
+    );
 }
 
 #[test]
 fn classes_attrs_ids_mixed_up() {
-    let s = html!(p { "Hi, " span.name.here lang="en" #thing { "Lyra" } "!" }).into_string();
+    let result = html! { p { "Hi, " span.name.here lang="en" #thing { "Lyra" } "!" } };
     assert_eq!(
-        s,
+        result.into_string(),
         r#"<p>Hi, <span class="name here" id="thing" lang="en">Lyra</span>!</p>"#
     );
 }
 
 #[test]
 fn div_shorthand_class() {
-    let s = html!(.awesome-class {}).into_string();
-    assert_eq!(s, r#"<div class="awesome-class"></div>"#);
+    let result = html! { .awesome-class {} };
+    assert_eq!(result.into_string(), r#"<div class="awesome-class"></div>"#);
 }
 
 #[test]
 fn div_shorthand_id() {
-    let s = html!(#unique-id {}).into_string();
-    assert_eq!(s, r#"<div id="unique-id"></div>"#);
+    let result = html! { #unique-id {} };
+    assert_eq!(result.into_string(), r#"<div id="unique-id"></div>"#);
 }
 
 #[test]
 fn div_shorthand_class_with_attrs() {
-    let s = html!(.awesome-class contenteditable? dir="rtl" #unique-id {}).into_string();
+    let result = html! { .awesome-class contenteditable? dir="rtl" #unique-id {} };
     assert_eq!(
-        s,
+        result.into_string(),
         r#"<div class="awesome-class" id="unique-id" contenteditable dir="rtl"></div>"#
     );
 }
 
 #[test]
 fn div_shorthand_id_with_attrs() {
-    let s = html!(#unique-id contenteditable? dir="rtl" .awesome-class {}).into_string();
+    let result = html! { #unique-id contenteditable? dir="rtl" .awesome-class {} };
     assert_eq!(
-        s,
+        result.into_string(),
         r#"<div class="awesome-class" id="unique-id" contenteditable dir="rtl"></div>"#
     );
 }

--- a/maud/tests/control_structures.rs
+++ b/maud/tests/control_structures.rs
@@ -3,7 +3,7 @@ use maud::html;
 #[test]
 fn if_expr() {
     for (number, &name) in (1..4).zip(["one", "two", "three"].iter()) {
-        let s = html! {
+        let result = html! {
             @if number == 1 {
                 "one"
             } @else if number == 2 {
@@ -13,9 +13,8 @@ fn if_expr() {
             } @else {
                 "oh noes"
             }
-        }
-        .into_string();
-        assert_eq!(s, name);
+        };
+        assert_eq!(result.into_string(), name);
     }
 }
 
@@ -25,72 +24,73 @@ fn if_expr_in_class() {
         (0, r#"<p class="empty">Chocolate milk</p>"#),
         (1, r#"<p class="full">Chocolate milk</p>"#),
     ] {
-        let s = html! {
+        let result = html! {
             p.@if chocolate_milk == 0 { "empty" } @else { "full" } {
                 "Chocolate milk"
             }
-        }
-        .into_string();
-        assert_eq!(s, expected);
+        };
+        assert_eq!(result.into_string(), expected);
     }
 }
 
 #[test]
 fn if_let() {
     for &(input, output) in &[(Some("yay"), "yay"), (None, "oh noes")] {
-        let s = html! {
+        let result = html! {
             @if let Some(value) = input {
                 (value)
             } @else {
                 "oh noes"
             }
-        }
-        .into_string();
-        assert_eq!(s, output);
+        };
+        assert_eq!(result.into_string(), output);
     }
 }
 
 #[test]
 fn while_expr() {
     let mut numbers = (0..3).into_iter().peekable();
-    let s = html! {
+    let result = html! {
         ul {
             @while numbers.peek().is_some() {
                 li { (numbers.next().unwrap()) }
             }
         }
-    }
-    .into_string();
-    assert_eq!(s, "<ul><li>0</li><li>1</li><li>2</li></ul>");
+    };
+    assert_eq!(
+        result.into_string(),
+        "<ul><li>0</li><li>1</li><li>2</li></ul>"
+    );
 }
 
 #[test]
 fn while_let_expr() {
     let mut numbers = (0..3).into_iter();
-    let s = html! {
+    let result = html! {
         ul {
             @while let Some(n) = numbers.next() {
                 li { (n) }
             }
         }
-    }
-    .into_string();
-    assert_eq!(s, "<ul><li>0</li><li>1</li><li>2</li></ul>");
+    };
+    assert_eq!(
+        result.into_string(),
+        "<ul><li>0</li><li>1</li><li>2</li></ul>"
+    );
 }
 
 #[test]
 fn for_expr() {
     let ponies = ["Apple Bloom", "Scootaloo", "Sweetie Belle"];
-    let s = html! {
+    let result = html! {
         ul {
             @for pony in &ponies {
                 li { (pony) }
             }
         }
-    }
-    .into_string();
+    };
     assert_eq!(
-        s,
+        result.into_string(),
         concat!(
             "<ul>",
             "<li>Apple Bloom</li>",
@@ -104,7 +104,7 @@ fn for_expr() {
 #[test]
 fn match_expr() {
     for &(input, output) in &[(Some("yay"), "<div>yay</div>"), (None, "oh noes")] {
-        let s = html! {
+        let result = html! {
             @match input {
                 Some(value) => {
                     div { (value) }
@@ -113,52 +113,48 @@ fn match_expr() {
                     "oh noes"
                 },
             }
-        }
-        .into_string();
-        assert_eq!(s, output);
+        };
+        assert_eq!(result.into_string(), output);
     }
 }
 
 #[test]
 fn match_expr_without_delims() {
     for &(input, output) in &[(Some("yay"), "yay"), (None, "<span>oh noes</span>")] {
-        let s = html! {
+        let result = html! {
             @match input {
                 Some(value) => (value),
                 None => span { "oh noes" },
             }
-        }
-        .into_string();
-        assert_eq!(s, output);
+        };
+        assert_eq!(result.into_string(), output);
     }
 }
 
 #[test]
 fn match_no_trailing_comma() {
     for &(input, output) in &[(Some("yay"), "yay"), (None, "<span>oh noes</span>")] {
-        let s = html! {
+        let result = html! {
             @match input {
                 Some(value) => { (value) }
                 None => span { "oh noes" }
             }
-        }
-        .into_string();
-        assert_eq!(s, output);
+        };
+        assert_eq!(result.into_string(), output);
     }
 }
 
 #[test]
 fn match_expr_with_guards() {
     for &(input, output) in &[(Some(1), "one"), (None, "none"), (Some(2), "2")] {
-        let s = html! {
+        let result = html! {
             @match input {
                 Some(value) if value == 1 => "one",
                 Some(value) => (value),
                 None => "none",
             }
-        }
-        .into_string();
-        assert_eq!(s, output);
+        };
+        assert_eq!(result.into_string(), output);
     }
 }
 
@@ -169,51 +165,47 @@ fn match_in_attribute() {
         (2, "<span class=\"two\">2</span>"),
         (3, "<span class=\"many\">3</span>"),
     ] {
-        let s = html! {
+        let result = html! {
             span class=@match input {
                 1 => "one",
                 2 => "two",
                 _ => "many",
             } { (input) }
-        }
-        .into_string();
-        assert_eq!(s, output);
+        };
+        assert_eq!(result.into_string(), output);
     }
 }
 
 #[test]
 fn let_expr() {
-    let s = html! {
+    let result = html! {
         @let x = 42;
         "I have " (x) " cupcakes!"
-    }
-    .into_string();
-    assert_eq!(s, "I have 42 cupcakes!");
+    };
+    assert_eq!(result.into_string(), "I have 42 cupcakes!");
 }
 
 #[test]
 fn let_lexical_scope() {
     let x = 42;
-    let s = html! {
+    let result = html! {
         {
             @let x = 99;
             "Twilight thought I had " (x) " cupcakes, "
         }
         "but I only had " (x) "."
-    }
-    .into_string();
+    };
     assert_eq!(
-        s,
+        result.into_string(),
         concat!("Twilight thought I had 99 cupcakes, ", "but I only had 42.")
     );
 }
 
 #[test]
 fn let_type_ascription() {
-    let s = html! {
+    let result = html! {
         @let mut x: Box<dyn Iterator<Item=u32>> = Box::new(vec![42].into_iter());
         "I have " (x.next().unwrap()) " cupcakes!"
-    }
-    .into_string();
-    assert_eq!(s, "I have 42 cupcakes!");
+    };
+    assert_eq!(result.into_string(), "I have 42 cupcakes!");
 }

--- a/maud/tests/misc.rs
+++ b/maud/tests/misc.rs
@@ -3,7 +3,7 @@ use maud::{self, html};
 #[test]
 fn issue_13() {
     let owned = String::from("yay");
-    let _ = html!((owned));
+    let _ = html! { (owned) };
     // Make sure the `html!` call didn't move it
     let _owned = owned;
 }
@@ -11,39 +11,44 @@ fn issue_13() {
 #[test]
 fn issue_21() {
     macro_rules! greet {
-        () => ({
+        () => {{
             let name = "Pinkie Pie";
-            html!(p { "Hello, " (name) "!" })
-        })
+            html! {
+                p { "Hello, " (name) "!" }
+            }
+        }};
     }
 
-    let s = greet!().into_string();
-    assert_eq!(s, "<p>Hello, Pinkie Pie!</p>");
+    assert_eq!(greet!().into_string(), "<p>Hello, Pinkie Pie!</p>");
 }
 
 #[test]
 fn issue_21_2() {
     macro_rules! greet {
-        ($name:expr) => ({
-            html!(p { "Hello, " ($name) "!" })
-        })
+        ($name:expr) => {{
+            html! {
+                p { "Hello, " ($name) "!" }
+            }
+        }};
     }
 
-    let s = greet!("Pinkie Pie").into_string();
-    assert_eq!(s, "<p>Hello, Pinkie Pie!</p>");
+    assert_eq!(
+        greet!("Pinkie Pie").into_string(),
+        "<p>Hello, Pinkie Pie!</p>"
+    );
 }
 
 #[test]
 fn issue_23() {
     macro_rules! wrapper {
         ($($x:tt)*) => {{
-            html!($($x)*)
+            html! { $($x)* }
         }}
     }
 
     let name = "Lyra";
-    let s = wrapper!(p { "Hi, " (name) "!" }).into_string();
-    assert_eq!(s, "<p>Hi, Lyra!</p>");
+    let result = wrapper!(p { "Hi, " (name) "!" });
+    assert_eq!(result.into_string(), "<p>Hi, Lyra!</p>");
 }
 
 #[test]
@@ -58,10 +63,10 @@ fn render_impl() {
     let r = R("pinkie");
     // Since `R` is not `Copy`, this shows that Maud will auto-ref splice
     // arguments to find a `Render` impl
-    let s1 = html!((r)).into_string();
-    let s2 = html!((r)).into_string();
-    assert_eq!(s1, "pinkie");
-    assert_eq!(s2, "pinkie");
+    let result_a = html! { (r) };
+    let result_b = html! { (r) };
+    assert_eq!(result_a.into_string(), "pinkie");
+    assert_eq!(result_b.into_string(), "pinkie");
 }
 
 #[test]
@@ -76,5 +81,5 @@ fn issue_97() {
         }
     }
 
-    assert_eq!(html!((Pinkie)).into_string(), "42");
+    assert_eq!(html! { (Pinkie) }.into_string(), "42");
 }

--- a/maud/tests/splices.rs
+++ b/maud/tests/splices.rs
@@ -2,20 +2,20 @@ use maud::html;
 
 #[test]
 fn literals() {
-    let s = html!(("<pinkie>")).into_string();
-    assert_eq!(s, "&lt;pinkie&gt;");
+    let result = html! { ("<pinkie>") };
+    assert_eq!(result.into_string(), "&lt;pinkie&gt;");
 }
 
 #[test]
 fn raw_literals() {
     use maud::PreEscaped;
-    let s = html!((PreEscaped("<pinkie>"))).into_string();
-    assert_eq!(s, "<pinkie>");
+    let result = html! { (PreEscaped("<pinkie>")) };
+    assert_eq!(result.into_string(), "<pinkie>");
 }
 
 #[test]
 fn blocks() {
-    let s = html!({
+    let result = html! {
         ({
             let mut result = 1i32;
             for i in 2..11 {
@@ -23,52 +23,54 @@ fn blocks() {
             }
             result
         })
-    })
-    .into_string();
-    assert_eq!(s, "3628800");
+    };
+    assert_eq!(result.into_string(), "3628800");
 }
 
 #[test]
 fn attributes() {
     let alt = "Pinkie Pie";
-    let s = html!(img src="pinkie.jpg" alt=(alt) /).into_string();
-    assert_eq!(s, r#"<img src="pinkie.jpg" alt="Pinkie Pie">"#);
+    let result = html! { img src="pinkie.jpg" alt=(alt) / };
+    assert_eq!(
+        result.into_string(),
+        r#"<img src="pinkie.jpg" alt="Pinkie Pie">"#
+    );
 }
 
 #[test]
 fn class_shorthand() {
     let pinkie_class = "pinkie";
-    let s = html!(p.(pinkie_class) { "Fun!" }).into_string();
-    assert_eq!(s, r#"<p class="pinkie">Fun!</p>"#);
+    let result = html! { p.(pinkie_class) { "Fun!" } };
+    assert_eq!(result.into_string(), r#"<p class="pinkie">Fun!</p>"#);
 }
 
 #[test]
 fn class_shorthand_block() {
     let class_prefix = "pinkie-";
-    let s = html!(p.{ (class_prefix) "123" } { "Fun!" }).into_string();
-    assert_eq!(s, r#"<p class="pinkie-123">Fun!</p>"#);
+    let result = html! { p.{ (class_prefix) "123" } { "Fun!" } };
+    assert_eq!(result.into_string(), r#"<p class="pinkie-123">Fun!</p>"#);
 }
 
 #[test]
 fn id_shorthand() {
     let pinkie_id = "pinkie";
-    let s = html!(p#(pinkie_id) { "Fun!" }).into_string();
-    assert_eq!(s, r#"<p id="pinkie">Fun!</p>"#);
+    let result = html! { p#(pinkie_id) { "Fun!" } };
+    assert_eq!(result.into_string(), r#"<p id="pinkie">Fun!</p>"#);
 }
 
 static BEST_PONY: &'static str = "Pinkie Pie";
 
 #[test]
 fn statics() {
-    let s = html!((BEST_PONY)).into_string();
-    assert_eq!(s, "Pinkie Pie");
+    let result = html! { (BEST_PONY) };
+    assert_eq!(result.into_string(), "Pinkie Pie");
 }
 
 #[test]
 fn locals() {
     let best_pony = "Pinkie Pie";
-    let s = html!((best_pony)).into_string();
-    assert_eq!(s, "Pinkie Pie");
+    let result = html! { (best_pony) };
+    assert_eq!(result.into_string(), "Pinkie Pie");
 }
 
 /// An example struct, for testing purposes only
@@ -92,18 +94,17 @@ fn structs() {
         name: "Pinkie Pie",
         adorableness: 9,
     };
-    let s = html!({
+    let result = html! {
         "Name: " (pinkie.name) ". Rating: " (pinkie.repugnance())
-    })
-    .into_string();
-    assert_eq!(s, "Name: Pinkie Pie. Rating: 1");
+    };
+    assert_eq!(result.into_string(), "Name: Pinkie Pie. Rating: 1");
 }
 
 #[test]
 fn tuple_accessors() {
     let a = ("ducks", "geese");
-    let s = html!((a.0)).into_string();
-    assert_eq!(s, "ducks");
+    let result = html! { (a.0) };
+    assert_eq!(result.into_string(), "ducks");
 }
 
 #[test]
@@ -113,13 +114,13 @@ fn splice_with_path() {
             "Maud"
         }
     }
-    let s = html!((inner::name())).into_string();
-    assert_eq!(s, "Maud");
+    let result = html! { (inner::name()) };
+    assert_eq!(result.into_string(), "Maud");
 }
 
 #[test]
 fn nested_macro_invocation() {
     let best_pony = "Pinkie Pie";
-    let s = html!((format!("{} is best pony", best_pony))).into_string();
-    assert_eq!(s, "Pinkie Pie is best pony");
+    let result = html! { (format!("{} is best pony", best_pony)) };
+    assert_eq!(result.into_string(), "Pinkie Pie is best pony");
 }

--- a/maud/tests/warnings/keyword-without-at.rs
+++ b/maud/tests/warnings/keyword-without-at.rs
@@ -1,0 +1,7 @@
+use maud::html;
+
+fn main() {
+    html! {
+        if {}
+    };
+}

--- a/maud/tests/warnings/keyword-without-at.stderr
+++ b/maud/tests/warnings/keyword-without-at.stderr
@@ -1,7 +1,7 @@
 error: found keyword `if`
- --> $DIR/keyword_names_without_@.rs:7:9
+ --> $DIR/keyword-without-at.rs:5:9
   |
-7 |         if {}
+5 |         if {}
   |         ^^
   |
   = help: should this be a `@if`?

--- a/maud/tests/warnings/keyword_names_without_@.rs
+++ b/maud/tests/warnings/keyword_names_without_@.rs
@@ -1,9 +1,0 @@
-extern crate maud_macros;
-
-use maud_macros::html;
-
-fn main() {
-    html! {
-        if {}
-    };
-}


### PR DESCRIPTION
- Call `.into_string()` later
- Rename UI test to match Rust convention