### PR TITLE
Remove `#![feature(extended_key_value_attributes)]`

### DIFF
--- a/doctest/build.rs
+++ b/doctest/build.rs
@@ -10,7 +10,6 @@ fn main() {
 
     let mut buffer = r#"// Automatically @generated – do not edit
 
-#![feature(extended_key_value_attributes)]
 "#.to_string();
 
     for entry in fs::read_dir(DOCS_DIR).unwrap() {


### PR DESCRIPTION
Closes #273