### PR TITLE
Support for Rocket 0.5

### DIFF
--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -21,7 +21,7 @@ actix-web = ["actix-web-dep", "futures-util"]
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 maud_macros = { version = "0.22.2", path = "../maud_macros" }
 iron = { version = ">= 0.5.1, < 0.7.0", optional = true }
-rocket = { version = ">= 0.3, < 0.5", optional = true }
+rocket = { version = ">= 0.3, < 0.6", optional = true }
 futures-util = { version = "0.3.0", optional = true, default-features = false }
 actix-web-dep = { package = "actix-web", version = ">= 2, < 4", optional = true, default-features = false }
 


### PR DESCRIPTION
The trait that Maud needs to implement is still the same in Release-Candidate 1 of Rocket 0.5, so simply raising the maximum version of rocket enables Maud to work.