### PR TITLE
Using no_std + alloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Support `no_std` + `alloc`.
+  [#278](https://github.com/lambda-fairy/maud/issues/278)
+
 ## [0.22.2] - 2021-01-09
 
 - Don't require `?` suffix for empty attributes. The old syntax is kept for backward compatibility.

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -9,11 +9,6 @@
 
 #![doc(html_root_url = "https://docs.rs/maud/0.22.2")]
 
-// the `iron` and `rocket` features needs `std`.
-#[cfg(any(feature = "iron", feature = "rocket"))]
-#[macro_use]
-extern crate std;
-
 extern crate alloc;
 
 use alloc::string::String;
@@ -178,6 +173,8 @@ pub const DOCTYPE: PreEscaped<&'static str> = PreEscaped("<!DOCTYPE html>");
 
 #[cfg(feature = "iron")]
 mod iron_support {
+    extern crate std;
+
     use crate::PreEscaped;
     use alloc::boxed::Box;
     use alloc::string::String;
@@ -204,6 +201,8 @@ mod iron_support {
 
 #[cfg(feature = "rocket")]
 mod rocket_support {
+    extern crate std;
+
     use crate::PreEscaped;
     use alloc::string::String;
     use rocket::http::{ContentType, Status};

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //! A macro for writing HTML templates.
 //!
 //! This documentation only describes the runtime API. For a general
@@ -7,7 +9,15 @@
 
 #![doc(html_root_url = "https://docs.rs/maud/0.22.2")]
 
-use std::fmt::{self, Write};
+// the `iron` and `rocket` features needs `std`.
+#[cfg(any(feature = "iron", feature = "rocket"))]
+#[macro_use]
+extern crate std;
+
+extern crate alloc;
+
+use alloc::string::String;
+use core::fmt::{self, Write};
 
 pub use maud_macros::{html, html_debug};
 
@@ -89,8 +99,9 @@ impl<T: fmt::Display + ?Sized> Render for T {
 #[doc(hidden)]
 pub mod render {
     use crate::Render;
+    use alloc::string::String;
+    use core::fmt::Write;
     use maud_htmlescape::Escaper;
-    use std::fmt::Write;
 
     pub trait RenderInternal {
         fn __maud_render_to(&self, w: &mut String);
@@ -168,6 +179,8 @@ pub const DOCTYPE: PreEscaped<&'static str> = PreEscaped("<!DOCTYPE html>");
 #[cfg(feature = "iron")]
 mod iron_support {
     use crate::PreEscaped;
+    use alloc::boxed::Box;
+    use alloc::string::String;
     use iron::headers::ContentType;
     use iron::modifier::{Modifier, Set};
     use iron::modifiers::Header;
@@ -192,6 +205,7 @@ mod iron_support {
 #[cfg(feature = "rocket")]
 mod rocket_support {
     use crate::PreEscaped;
+    use alloc::string::String;
     use rocket::http::{ContentType, Status};
     use rocket::request::Request;
     use rocket::response::{Responder, Response};
@@ -211,6 +225,7 @@ mod rocket_support {
 mod actix_support {
     use crate::PreEscaped;
     use actix_web_dep::{Error, HttpRequest, HttpResponse, Responder};
+    use alloc::string::String;
     use futures_util::future::{ok, Ready};
 
     impl Responder for PreEscaped<String> {

--- a/maud_htmlescape/lib.rs
+++ b/maud_htmlescape/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(test), no_std)]
+
 //! Internal support code used by the [Maud] template engine.
 //!
 //! You should not need to depend on this crate directly.
@@ -6,6 +8,9 @@
 
 #![doc(html_root_url = "https://docs.rs/maud_htmlescape/0.17.0")]
 
+extern crate alloc;
+
+use alloc::string::String;
 use core::fmt;
 
 /// An adapter that escapes HTML special characters.

--- a/maud_htmlescape/lib.rs
+++ b/maud_htmlescape/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(html_root_url = "https://docs.rs/maud_htmlescape/0.17.0")]
 
-use std::fmt;
+use core::fmt;
 
 /// An adapter that escapes HTML special characters.
 ///

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -36,7 +36,8 @@ fn expand(input: TokenStream) -> TokenStream {
     let stmts = generate::generate(markups, output_ident.clone());
     quote!({
         extern crate maud;
-        let mut #output_ident = ::std::string::String::with_capacity(#size_hint);
+        extern crate alloc;
+        let mut #output_ident = alloc::string::String::with_capacity(#size_hint);
         #stmts
         maud::PreEscaped(#output_ident)
     })

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -37,7 +37,7 @@ fn expand(input: TokenStream) -> TokenStream {
     quote!({
         extern crate alloc;
         extern crate maud;
-        let mut #output_ident = ::alloc::string::String::with_capacity(#size_hint);
+        let mut #output_ident = alloc::string::String::with_capacity(#size_hint);
         #stmts
         maud::PreEscaped(#output_ident)
     })

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -35,9 +35,9 @@ fn expand(input: TokenStream) -> TokenStream {
     let markups = parse::parse(input);
     let stmts = generate::generate(markups, output_ident.clone());
     quote!({
-        extern crate maud;
         extern crate alloc;
-        let mut #output_ident = alloc::string::String::with_capacity(#size_hint);
+        extern crate maud;
+        let mut #output_ident = ::alloc::string::String::with_capacity(#size_hint);
         #stmts
         maud::PreEscaped(#output_ident)
     })


### PR DESCRIPTION
Removed references to `std` and replaced them with references to `core` and `alloc`.

Tests still use `std`.