### PR TITLE
ensure tide default-features are disabled

### DIFF
--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -24,7 +24,7 @@ iron = { version = ">= 0.5.1, < 0.7.0", optional = true }
 rocket = { version = ">= 0.3, < 0.5", optional = true }
 futures-util = { version = "0.3.0", optional = true, default-features = false }
 actix-web-dep = { package = "actix-web", version = ">= 2, < 4", optional = true, default-features = false }
-tide = { version = "0.16.0", optional = true }
+tide = { version = "0.16.0", optional = true, default-features = false }
 axum = { version = "0.1.3", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This ensures that maud itself doesn't dictate what features an author might like to use.