### PR TITLE
Remove Iron support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [#306](https://github.com/lambda-fairy/maud/pull/306)
 - Update to Rust 2021
   [#309](https://github.com/lambda-fairy/maud/pull/309)
+- Remove Iron support
+  [#289](https://github.com/lambda-fairy/maud/pull/289)
 
 ## [0.22.3] - 2021-09-27
 

--- a/docs/content/web-frameworks.md
+++ b/docs/content/web-frameworks.md
@@ -1,10 +1,9 @@
 # Web framework integration
 
 Maud includes support for these web frameworks:
-[Actix], [Iron], [Rocket], [Rouille], and [Tide].
+[Actix], [Rocket], [Rouille], and [Tide].
 
 [Actix]: https://actix.rs/
-[Iron]: http://ironframework.io
 [Rocket]: https://rocket.rs/
 [Rouille]: https://github.com/tomaka/rouille
 [Tide]: https://docs.rs/tide/
@@ -47,42 +46,6 @@ async fn main() -> io::Result<()> {
         .await
 }
 ```
-
-# Iron
-
-Iron support is available with the "iron" feature:
-
-```toml
-# ...
-[dependencies]
-maud = { version = "*", features = ["iron"] }
-# ...
-```
-
-With this feature enabled,
-you can then build a `Response` from a `Markup` object directly.
-Here's an example application using Iron and Maud:
-
-```rust,no_run
-use iron::prelude::*;
-use iron::status;
-use maud::html;
-
-fn main() {
-    Iron::new(|r: &mut Request| {
-        let markup = html! {
-            h1 { "Hello, world!" }
-            p {
-                "You are viewing the page at " (r.url)
-            }
-        };
-        Ok(Response::with((status::Ok, markup)))
-    }).http("localhost:3000").unwrap();
-}
-```
-
-`Markup` will set the content type of the response automatically,
-so you don't need to add it yourself.
 
 # Rocket
 

--- a/doctest/Cargo.toml
+++ b/doctest/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2018"
 [dependencies]
 actix-web = "3"
 ammonia = "3"
-iron = "0.6"
-maud = { path = "../maud", features = ["actix-web", "iron", "rocket", "tide", "axum"] }
+maud = { path = "../maud", features = ["actix-web", "rocket", "tide", "axum"] }
 pulldown-cmark = "0.8"
 rocket = "0.4"
 rouille = "3"

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -19,7 +19,6 @@ actix-web = ["actix-web-dep", "futures-util"]
 
 [dependencies]
 maud_macros = { version = "0.22.3", path = "../maud_macros" }
-iron = { version = ">= 0.5.1, < 0.7.0", optional = true }
 rocket = { version = ">= 0.3, < 0.5", optional = true }
 futures-util = { version = "0.3.0", optional = true, default-features = false }
 actix-web-dep = { package = "actix-web", version = ">= 2, < 4", optional = true, default-features = false }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -208,35 +208,6 @@ impl<T: AsRef<str> + Into<String>> From<PreEscaped<T>> for String {
 /// ```
 pub const DOCTYPE: PreEscaped<&'static str> = PreEscaped("<!DOCTYPE html>");
 
-#[cfg(feature = "iron")]
-mod iron_support {
-    extern crate std;
-
-    use crate::PreEscaped;
-    use alloc::{boxed::Box, string::String};
-    use iron::{
-        headers::ContentType,
-        modifier::{Modifier, Set},
-        modifiers::Header,
-        response::{Response, WriteBody},
-    };
-    use std::io;
-
-    impl Modifier<Response> for PreEscaped<String> {
-        fn modify(self, response: &mut Response) {
-            response
-                .set_mut(Header(ContentType::html()))
-                .set_mut(Box::new(self) as Box<dyn WriteBody>);
-        }
-    }
-
-    impl WriteBody for PreEscaped<String> {
-        fn write_body(&mut self, body: &mut dyn io::Write) -> io::Result<()> {
-            self.0.write_body(body)
-        }
-    }
-}
-
 #[cfg(feature = "rocket")]
 mod rocket_support {
     extern crate std;


### PR DESCRIPTION
The Iron framework hasn't been updated in a long time. It still uses outdated versions of libraries like futures 0.1, hyper 0.12, url 1.7. We can clean up the repo by removing it. This will also slightly speed up CI.