### PR TITLE
Restrict proc-macro2 version

### DIFF
--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 syn = "1.0.8"
 maud_htmlescape = { version = "0.17.0", path = "../maud_htmlescape" }
 quote = "1.0.7"
-proc-macro2 = "1.0.19"
+proc-macro2 = ">=1.0.23,<1.0.29"
 proc-macro-error = "1.0.0"
 
 [lib]


### PR DESCRIPTION
When I try to compile maud (rustc 1.54.0), I get the following error:

```
error[E0599]: no function or associated item named `from_str` found for struct `proc_macro::Literal` in the current scope
   --> /home/guido/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-1.0.29/src/wrapper.rs:926:38
    |
926 |                 proc_macro::Literal::from_str(repr)
    |                                      ^^^^^^^^ function or associated item not found in `proc_macro::Literal`
```

Everything still works with proc-macro2-1.0.28, but versions older than 1.0.23 won't compile either. Of course, this version pinning is just a workaround, but it is a quick fix so maud can be built again.

- maud does not build with proc-macro2 < 1.0.23
- maud does not build with proc-macro2 >= 1.0.28