### PR TITLE
Partially revert #309 for class shorthand

### DIFF
--- a/docs/content/elements-attributes.md
+++ b/docs/content/elements-attributes.md
@@ -155,7 +155,7 @@ and mix and match them with other attributes:
 ```rust
 # let _ = maud::
 html! {
-    input #cannon .big .scary .bright-red type="button" value="Launch Party Cannon";
+    input #cannon .big.scary.bright-red type="button" value="Launch Party Cannon";
 }
 # ;
 ```
@@ -185,7 +185,7 @@ which otherwise wouldn't parse:
 ```rust
 # let _ = maud::
 html! {
-    div ."col-sm-2" { "Bootstrap column!" }
+    div."col-sm-2" { "Bootstrap column!" }
 }
 # ;
 ```

--- a/docs/content/splices-toggles.md
+++ b/docs/content/splices-toggles.md
@@ -86,7 +86,7 @@ let severity = "critical";
 # let _ = maud::
 html! {
     aside #(name) {
-        p .{ "color-" (severity) } { "This is the worst! Possible! Thing!" }
+        p.{ "color-" (severity) } { "This is the worst! Possible! Thing!" }
     }
 }
 # ;
@@ -146,7 +146,7 @@ And classes:
 let cuteness = 95;
 # let _ = maud::
 html! {
-    p .cute[cuteness > 50] { "Squee!" }
+    p.cute[cuteness > 50] { "Squee!" }
 }
 # ;
 ```

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -189,15 +189,6 @@ fn hyphens_in_attribute_names() {
 
 #[test]
 fn class_shorthand() {
-    let result = html! { p { "Hi, " span .name { "Lyra" } "!" } };
-    assert_eq!(
-        result.into_string(),
-        r#"<p>Hi, <span class="name">Lyra</span>!</p>"#
-    );
-}
-
-#[test]
-fn class_shorthand_without_space() {
     let result = html! { p { "Hi, " span.name { "Lyra" } "!" } };
     assert_eq!(
         result.into_string(),
@@ -206,8 +197,17 @@ fn class_shorthand_without_space() {
 }
 
 #[test]
+fn class_shorthand_with_space() {
+    let result = html! { p { "Hi, " span .name { "Lyra" } "!" } };
+    assert_eq!(
+        result.into_string(),
+        r#"<p>Hi, <span class="name">Lyra</span>!</p>"#
+    );
+}
+
+#[test]
 fn classes_shorthand() {
-    let result = html! { p { "Hi, " span .name .here { "Lyra" } "!" } };
+    let result = html! { p { "Hi, " span.name.here { "Lyra" } "!" } };
     assert_eq!(
         result.into_string(),
         r#"<p>Hi, <span class="name here">Lyra</span>!</p>"#
@@ -216,7 +216,7 @@ fn classes_shorthand() {
 
 #[test]
 fn hyphens_in_class_names() {
-    let result = html! { p .rocks-these .are--my--rocks { "yes" } };
+    let result = html! { p.rocks-these.are--my--rocks { "yes" } };
     assert_eq!(
         result.into_string(),
         r#"<p class="rocks-these are--my--rocks">yes</p>"#
@@ -225,7 +225,7 @@ fn hyphens_in_class_names() {
 
 #[test]
 fn class_string() {
-    let result = html! { h1 ."pinkie-123" { "Pinkie Pie" } };
+    let result = html! { h1."pinkie-123" { "Pinkie Pie" } };
     assert_eq!(
         result.into_string(),
         r#"<h1 class="pinkie-123">Pinkie Pie</h1>"#
@@ -235,7 +235,7 @@ fn class_string() {
 #[test]
 fn toggle_classes() {
     fn test(is_cupcake: bool, is_muffin: bool) -> Markup {
-        html!(p .cupcake[is_cupcake] .muffin[is_muffin] { "Testing!" })
+        html!(p.cupcake[is_cupcake].muffin[is_muffin] { "Testing!" })
     }
     assert_eq!(
         test(true, true).into_string(),
@@ -260,7 +260,7 @@ fn toggle_classes_braces() {
     struct Maud {
         rocks: bool,
     }
-    let result = html! { p .rocks[Maud { rocks: true }.rocks] { "Awesome!" } };
+    let result = html! { p.rocks[Maud { rocks: true }.rocks] { "Awesome!" } };
     assert_eq!(result.into_string(), r#"<p class="rocks">Awesome!</p>"#);
 }
 
@@ -268,14 +268,14 @@ fn toggle_classes_braces() {
 fn toggle_classes_string() {
     let is_cupcake = true;
     let is_muffin = false;
-    let result = html! { p ."cupcake"[is_cupcake] ."is_muffin"[is_muffin] { "Testing!" } };
+    let result = html! { p."cupcake"[is_cupcake]."is_muffin"[is_muffin] { "Testing!" } };
     assert_eq!(result.into_string(), r#"<p class="cupcake">Testing!</p>"#);
 }
 
 #[test]
 fn mixed_classes() {
     fn test(is_muffin: bool) -> Markup {
-        html!(p .cupcake .muffin[is_muffin] .lamington { "Testing!" })
+        html!(p.cupcake.muffin[is_muffin].lamington { "Testing!" })
     }
     assert_eq!(
         test(true).into_string(),
@@ -307,7 +307,7 @@ fn id_string() {
 
 #[test]
 fn classes_attrs_ids_mixed_up() {
-    let result = html! { p { "Hi, " span .name .here lang="en" #thing { "Lyra" } "!" } };
+    let result = html! { p { "Hi, " span.name.here lang="en" #thing { "Lyra" } "!" } };
     assert_eq!(
         result.into_string(),
         r#"<p>Hi, <span class="name here" id="thing" lang="en">Lyra</span>!</p>"#

--- a/maud/tests/splices.rs
+++ b/maud/tests/splices.rs
@@ -40,14 +40,14 @@ fn attributes() {
 #[test]
 fn class_shorthand() {
     let pinkie_class = "pinkie";
-    let result = html! { p .(pinkie_class) { "Fun!" } };
+    let result = html! { p.(pinkie_class) { "Fun!" } };
     assert_eq!(result.into_string(), r#"<p class="pinkie">Fun!</p>"#);
 }
 
 #[test]
 fn class_shorthand_block() {
     let class_prefix = "pinkie-";
-    let result = html! { p .{ (class_prefix) "123" } { "Fun!" } };
+    let result = html! { p.{ (class_prefix) "123" } { "Fun!" } };
     assert_eq!(result.into_string(), r#"<p class="pinkie-123">Fun!</p>"#);
 }
 


### PR DESCRIPTION
On reflection, the extra spaces around classes feels weird to me. Let's revert that (but keep the 2021 edition migration in place).