### PR TITLE
Disallow slashes (`/`) in void elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   [#309](https://github.com/lambda-fairy/maud/pull/309)
 - Remove Iron support
   [#289](https://github.com/lambda-fairy/maud/pull/289)
+- Disallow slashes (`/`) in void elements
+  [#315](https://github.com/lambda-fairy/maud/pull/315)
 
 ## [0.22.3] - 2021-09-27
 

--- a/docs/content/elements-attributes.md
+++ b/docs/content/elements-attributes.md
@@ -16,13 +16,6 @@ html! {
 # ;
 ```
 
-Before version 0.18,
-Maud allowed the curly braces to be omitted.
-This syntax was [removed][#137]
-and now causes an error instead.
-
-[#137]: https://github.com/lambda-fairy/maud/pull/137
-
 ## Void elements: `br;`
 
 Terminate a void element using a semicolon:
@@ -46,13 +39,6 @@ html! {
 
 The result will be rendered with HTML syntax –
 `<br>` not `<br />`.
-
-Maud also supports ending a void element with a slash:
-`br /`.
-This syntax is [deprecated][#96]
-and should not be used in new code.
-
-[#96]: https://github.com/lambda-fairy/maud/pull/96
 
 ## Custom elements and `data` attributes
 

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -52,12 +52,6 @@ fn empty_elements() {
 }
 
 #[test]
-fn empty_elements_slash() {
-    let result = html! { "pinkie" br / "pie" };
-    assert_eq!(result.into_string(), "pinkie<br>pie");
-}
-
-#[test]
 fn simple_attributes() {
     let result = html! {
         link rel="stylesheet" href="styles.css";

--- a/maud/tests/warnings/void-element-slash.rs
+++ b/maud/tests/warnings/void-element-slash.rs
@@ -1,0 +1,9 @@
+use maud::html;
+
+fn main() {
+    html! {
+        br /
+        // Make sure we're not stopping on the first error
+        input type="text" /
+    };
+}

--- a/maud/tests/warnings/void-element-slash.stderr
+++ b/maud/tests/warnings/void-element-slash.stderr
@@ -1,0 +1,17 @@
+error: void elements must use `;`, not `/`
+ --> $DIR/void-element-slash.rs:5:12
+  |
+5 |         br /
+  |            ^
+  |
+  = help: change this to `;`
+  = help: see https://github.com/lambda-fairy/maud/pull/96 for details
+
+error: void elements must use `;`, not `/`
+ --> $DIR/void-element-slash.rs:7:27
+  |
+7 |         input type="text" /
+  |                           ^
+  |
+  = help: change this to `;`
+  = help: see https://github.com/lambda-fairy/maud/pull/96 for details

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -538,6 +538,14 @@ impl Parser {
             {
                 // Void element
                 self.advance();
+                if punct.as_char() == '/' {
+                    emit_error!(
+                        punct,
+                        "void elements must use `;`, not `/`";
+                        help = "change this to `;`";
+                        help = "see https://github.com/lambda-fairy/maud/pull/96 for details";
+                    );
+                }
                 ast::ElementBody::Void {
                     semi_span: SpanRange::single_span(punct.span()),
                 }


### PR DESCRIPTION
# Overview

The following syntax will no longer work:

```rust
html! {
    br /
    link rel="stylesheet" href="styles.css" /
}
```

This should be changed to the following:

```rust
html! {
    br;
    link rel="stylesheet" href="styles.css";
}
```

# Rationale

The `;` syntax was introduced in #96; the rationale for it can be found there.

Removing support for the older `/` syntax will simplify the API surface, and allow for the space to be used for other things.