### PR TITLE
Run doctests again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         override: true
 
     - name: Doctest
-      run: cd doctest && cargo check
+      run: cd doctest && cargo test
 
   rustfmt:
     name: Rustfmt

--- a/docs/content/elements-attributes.md
+++ b/docs/content/elements-attributes.md
@@ -14,7 +14,6 @@ html! {
     }
 }
 # ;
-invalid syntax !
 ```
 
 ## Void elements: `br;`

--- a/docs/content/elements-attributes.md
+++ b/docs/content/elements-attributes.md
@@ -14,6 +14,7 @@ html! {
     }
 }
 # ;
+invalid syntax !
 ```
 
 ## Void elements: `br;`


### PR DESCRIPTION
Per rust-lang/cargo#6424, `cargo check` doesn't actually run the doctests. So we need `cargo test` for this to work.