### PR TITLE
Update to axum-core 0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Remove blanket `Render` impl for `T: Display`
   [#320](https://github.com/lambda-fairy/maud/pull/320)
 - Update to axum-core 0.1. This requires axum 0.4
-  [#???](https://github.com/lambda-fairy/maud/pull/???)
+  [#325](https://github.com/lambda-fairy/maud/pull/325)
 
 ## [0.23.0] - 2021-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Remove blanket `Render` impl for `T: Display`
   [#320](https://github.com/lambda-fairy/maud/pull/320)
+- Update to axum-core 0.1. This requires axum 0.4
+  [#???](https://github.com/lambda-fairy/maud/pull/???)
 
 ## [0.23.0] - 2021-11-10
 

--- a/docs/content/web-frameworks.md
+++ b/docs/content/web-frameworks.md
@@ -159,7 +159,7 @@ This then allows you to use it directly as a response!
 
 ```rust,no_run
 use maud::{html, Markup};
-use axum::{Router, handler::get};
+use axum::{Router, routing::get};
 
 async fn hello_world() -> Markup {
     html! {

--- a/doctest/Cargo.toml
+++ b/doctest/Cargo.toml
@@ -13,7 +13,7 @@ rocket = "0.4"
 rouille = "3"
 tide = "0.16"
 tokio = { version = "1.9.0", features = ["rt", "macros", "rt-multi-thread"] }
-axum = "0.2"
+axum = "0.4"
 
 [dependencies.async-std]
 version = "1.9.0"

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 
 [features]
 default = []
+axum = ["axum-core", "http"]
 
 # Web framework integrations
 actix-web = ["actix-web-dep", "futures-util"]
@@ -24,7 +25,8 @@ rocket = { version = ">= 0.3, < 0.5", optional = true }
 futures-util = { version = "0.3.0", optional = true, default-features = false }
 actix-web-dep = { package = "actix-web", version = ">= 2, < 4", optional = true, default-features = false }
 tide = { version = "0.16.0", optional = true, default-features = false }
-axum = { version = "0.2", optional = true }
+axum-core = { version = "0.1", optional = true }
+http = { version = "0.2", optional = true }
 
 [dev-dependencies]
 trybuild = { version = "1.0.33", features = ["diff"] }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -296,24 +296,17 @@ mod tide_support {
 mod axum_support {
     use crate::PreEscaped;
     use alloc::string::String;
-    use axum::{
-        body::Body,
-        http::{header, HeaderValue, Response, StatusCode},
-        response::IntoResponse,
-    };
+    use axum_core::{body::BoxBody, response::IntoResponse};
+    use http::{header, HeaderMap, HeaderValue, Response};
 
     impl IntoResponse for PreEscaped<String> {
-        type Body = Body;
-        type BodyError = <Self::Body as axum::body::HttpBody>::Error;
-
-        fn into_response(self) -> Response<Body> {
-            let mut res = Response::new(Body::from(self.0));
-            *res.status_mut() = StatusCode::OK;
-            res.headers_mut().insert(
+        fn into_response(self) -> Response<BoxBody> {
+            let mut headers = HeaderMap::new();
+            headers.insert(
                 header::CONTENT_TYPE,
                 HeaderValue::from_static("text/html; charset=utf-8"),
             );
-            res
+            (headers, self.0).into_response()
         }
     }
 }


### PR DESCRIPTION
Together with the new 0.4 release of `axum` we made a new crate called
[`axum-core`]. `axum-core` has a small API and is less likely to receive
breaking changes. Therefore its recommended for libraries to depend on
`axum-core` instead of `axum`.

So this updates `maud` to use `axum-core`.

Note this is a breaking change since `axum-core` requires `axum` 0.4.

[`axum-core`]: https://crates.io/crates/axum-core