### PR TITLE
Use explicitly-named args in `impl_render_with_display`

### DIFF
--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -155,7 +155,7 @@ macro_rules! impl_render_with_display {
         $(
             impl Render for $ty {
                 fn render_to(&self, w: &mut String) {
-                    format_args!("{self}").render_to(w);
+                    format_args!("{self}", self=self).render_to(w);
                 }
             }
         )*

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -155,7 +155,8 @@ macro_rules! impl_render_with_display {
         $(
             impl Render for $ty {
                 fn render_to(&self, w: &mut String) {
-                    format_args!("{self}", self=self).render_to(w);
+                    // TODO: remove the explicit arg when Rust 1.58 is released
+                    format_args!("{self}", self = self).render_to(w);
                 }
             }
         )*


### PR DESCRIPTION
Implicitly-named format args were introduced in 69649421686a16206d55eb31634f2b77f8aa504e as part of the work on #320, but it does not appear that feature will land until Rust 1.58. Explicitly naming the args ensures that the Maud works on non-Nightly builds of Rust.