### PR TITLE
Add Poem support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [#325](https://github.com/lambda-fairy/maud/pull/325)
 - Update to `actix-web` 4.0.
   [#331](https://github.com/lambda-fairy/maud/pull/331)
+- Add support for `poem`.
+  [#333](https://github.com/lambda-fairy/maud/pull/333)
 
 ## [0.23.0] - 2021-11-10
 

--- a/docs/content/web-frameworks.md
+++ b/docs/content/web-frameworks.md
@@ -179,3 +179,41 @@ async fn main() {
         .unwrap();
 }
 ```
+
+# Poem
+
+Poem support is available with the "poem" feature:
+
+```toml
+# ...
+[dependencies]
+maud = { version = "*", features = ["poem"] }
+# ...
+```
+
+This adds an implementation of `IntoResponse` for `Markup`/`PreEscaped<String>`.
+This then allows you to use it directly as a response!
+
+```rust,no_run
+use std::net::SocketAddr;
+
+use maud::{html, Markup};
+use poem::{get, handler, listener::TcpListener, Route, Server};
+
+#[handler]
+fn hello_world() -> Markup {
+    html! {
+        h1 { "Hello, World!" }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // build our application with a single route
+    let app = Route::new().at("/", get(hello_world));
+
+    // run it with hyper on localhost:3000
+    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
+    Server::new(TcpListener::bind(addr)).run(app).await.unwrap();
+}
+```

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -26,6 +26,7 @@ futures-util = { version = "0.3.0", optional = true, default-features = false }
 actix-web-dep = { package = "actix-web", version = "4", optional = true, default-features = false }
 tide = { version = "0.16.0", optional = true, default-features = false }
 axum-core = { version = "0.1", optional = true }
+poem = { version = "~1", optional = true }
 http = { version = "0.2", optional = true }
 
 [dev-dependencies]

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -311,3 +311,24 @@ mod axum_support {
         }
     }
 }
+
+#[cfg(feature = "poem")]
+mod poem_support {
+    use crate::PreEscaped;
+    use alloc::string::String;
+    use poem::{
+        http::{header, HeaderMap, HeaderValue},
+        IntoResponse, Response,
+    };
+
+    impl IntoResponse for PreEscaped<String> {
+        fn into_response(self) -> Response {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("text/html; charset=utf-8"),
+            );
+            (headers, self.0).into_response()
+        }
+    }
+}


### PR DESCRIPTION
Adds support for [Poem](https://docs.rs/poem/latest/poem/) `IntoResponse`.

I didn't add any tests: I didn't see any for `axum`, and this is a similar type-level change.
It also looks like we don't have a great way to test stuff like this in general in the repo right now.

I did test with a local project, attached:
[maud_example.zip](https://github.com/lambda-fairy/maud/files/8238367/maud_example.zip)