### PR TITLE
Add ability to read html from file

### DIFF
--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -14,7 +14,7 @@ extern crate alloc;
 use alloc::{borrow::Cow, boxed::Box, string::String};
 use core::fmt::{self, Arguments, Write};
 
-pub use maud_macros::{html, html_debug};
+pub use maud_macros::{html, html_debug, html_file};
 
 mod escape;
 

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -11,8 +11,18 @@ mod generate;
 mod parse;
 
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
-use proc_macro_error::proc_macro_error;
+use proc_macro_error::{abort_call_site, proc_macro_error};
 use quote::quote;
+use std::{
+    env,
+    ffi::OsStr,
+    fmt::Display,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+use syn::{parse_macro_input, LitStr};
 
 #[proc_macro]
 #[proc_macro_error]
@@ -26,6 +36,40 @@ pub fn html_debug(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let expr = expand(input.into());
     println!("expansion:\n{}", expr);
     expr.into()
+}
+
+#[proc_macro]
+#[proc_macro_error]
+pub fn html_file(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let orig_path = parse_macro_input!(input as LitStr);
+    let root = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    let path = Path::new(&root).join(&orig_path.value());
+
+    let file_name = path.file_name().unwrap_or_else(|| OsStr::new("unknown"));
+
+    let mut file = abort_on_error(file_name, "error while opening", || {
+        File::open(<PathBuf as AsRef<Path>>::as_ref(&path))
+    });
+    let mut file_contents = String::new();
+    abort_on_error(file_name, "error while reading", || {
+        file.read_to_string(&mut file_contents)
+    });
+
+    expand(abort_on_error(file_name, "error while parsing", || {
+        TokenStream::from_str(&file_contents)
+    }))
+    .into()
+}
+
+fn abort_on_error<T, F, E>(file_name: &OsStr, description: &str, f: F) -> T
+where
+    F: FnOnce() -> Result<T, E>,
+    E: Display,
+{
+    match f() {
+        Ok(result) => result,
+        Err(error) => abort_call_site!("{} {:?}: {}", description, file_name, error),
+    }
 }
 
 fn expand(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
This allows for using external html, when it's a big chunk it's better to read when not part of the rust file.
```
html_file!("templates/base.maud");
```
It will be searched relative to the project root.

I've tested this only on top of https://github.com/lambda-fairy/maud/pull/322 and rocket 0.5 support, not on actual main but it should be of no difference.
