### PR TITLE
Bump itoa to v1

### DIFF
--- a/docs/Cargo.lock
+++ b/docs/Cargo.lock
@@ -212,12 +212,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
@@ -253,7 +247,7 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 name = "maud"
 version = "0.24.0"
 dependencies = [
- "itoa 0.4.8",
+ "itoa",
  "maud_macros",
 ]
 
@@ -506,7 +500,7 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -588,7 +582,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "libc",
  "num_threads",
 ]

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -20,7 +20,7 @@ axum = ["axum-core", "http"]
 
 [dependencies]
 maud_macros = { version = "0.24.0", path = "../maud_macros" }
-itoa = { version = "0.4.8", default-features = false, features = ["i128"] }
+itoa = "1"
 rocket = { version = ">= 0.3, < 0.5", optional = true }
 futures-util = { version = "0.3.0", optional = true, default-features = false }
 actix-web-dep = { package = "actix-web", version = "4", optional = true, default-features = false }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -172,7 +172,7 @@ macro_rules! impl_render_with_itoa {
         $(
             impl Render for $ty {
                 fn render_to(&self, w: &mut String) {
-                    let _ = itoa::fmt(w, *self);
+                    w.push_str(itoa::Buffer::new().format(*self));
                 }
             }
         )*


### PR DESCRIPTION
itoa 0.4 used `mem::uninitialized`, which is a very bad API as it's way of doing uninitialized memory goes against Rust's memory model. Starting from 1.64 it's slower because of the [forced memory initialization](https://github.com/rust-lang/rust/pull/99182/) it does to avoid the unsoundness