### PR TITLE
Support axum 0.6

### DIFF
--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -25,7 +25,7 @@ rocket = { version = ">= 0.3, < 0.5", optional = true }
 futures-util = { version = "0.3.0", optional = true, default-features = false }
 actix-web-dep = { package = "actix-web", version = "4", optional = true, default-features = false }
 tide = { version = "0.16.0", optional = true, default-features = false }
-axum-core = { version = "0.2", optional = true }
+axum-core = { version = "0.3.0-rc", optional = true }
 http = { version = "0.2", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Similar to the open PRs for the latest Rocket RC's this PR aims to act as a temporary hotfix until the latest axum is released.

Ignore this PR for now, I'll update it once axum 0.6 is ready.

For developers wishing to use the latest axum, add the following to your `Cargo.toml`:

```
maud = { git = "https://github.com/mhutter/maud", branch = "axum-0.6", features = ["axum"] }
```

(that is, if you trust me :smiling_imp: )