### PR TITLE
Add axum to the list of frameworks in docs

### DIFF
--- a/docs/content/web-frameworks.md
+++ b/docs/content/web-frameworks.md
@@ -1,11 +1,12 @@
 # Web framework integration
 
-Maud includes support for these web frameworks: [Actix], [Rocket], [Rouille], and [Tide].
+Maud includes support for these web frameworks: [Actix], [Rocket], [Rouille], [Tide] and [Axum].
 
 [Actix]: https://actix.rs/
 [Rocket]: https://rocket.rs/
 [Rouille]: https://github.com/tomaka/rouille
 [Tide]: https://docs.rs/tide/
+[Axum]: https://docs.rs/axum/
 
 # Actix
 


### PR DESCRIPTION
Axum was missing in the list at the top of the file.

Not sure if the other frameworks should be added to `index.md`,
only Rocket and Actix are mentioned there.