### PR TITLE
impl Default for PreEscaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [#357](https://github.com/lambda-fairy/maud/pull/357)
 - Support `axum` v0.6 through `axum-core` v0.3
   [#361](https://github.com/lambda-fairy/maud/pull/361)
+- Implement `Default` for `PreEscaped`
+  [#371](https://github.com/lambda-fairy/maud/pull/371)
 
 ## [0.24.0] - 2022-08-12
 

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -241,6 +241,12 @@ impl<T: AsRef<str> + Into<String>> From<PreEscaped<T>> for String {
     }
 }
 
+impl<T: AsRef<str> + Default> Default for PreEscaped<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
 /// The literal string `<!DOCTYPE html>`.
 ///
 /// # Example

--- a/maud/tests/misc.rs
+++ b/maud/tests/misc.rs
@@ -130,3 +130,10 @@ fn prefer_render_over_display() {
         "&lt;display&gt;"
     );
 }
+
+#[test]
+fn default() {
+    use maud::{Markup, PreEscaped};
+    assert_eq!(Markup::default().0, String::from(""));
+    assert_eq!(PreEscaped::<&'static str>::default().0, "");
+}

--- a/maud/tests/misc.rs
+++ b/maud/tests/misc.rs
@@ -134,6 +134,6 @@ fn prefer_render_over_display() {
 #[test]
 fn default() {
     use maud::{Markup, PreEscaped};
-    assert_eq!(Markup::default().0, String::from(""));
+    assert_eq!(Markup::default().0, "");
     assert_eq!(PreEscaped::<&'static str>::default().0, "");
 }


### PR DESCRIPTION
Tests was broken before the change, I'm not sure if I should fix them. But `cargo test misc` works.