### PR TITLE
PoC writing to existing buffer with html_to! macro

### DIFF
--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -14,7 +14,7 @@ extern crate alloc;
 use alloc::{borrow::Cow, boxed::Box, string::String};
 use core::fmt::{self, Arguments, Display, Write};
 
-pub use maud_macros::html;
+pub use maud_macros::{html, html_to};
 
 mod escape;
 

--- a/maud/tests/html_to.rs
+++ b/maud/tests/html_to.rs
@@ -1,0 +1,44 @@
+use maud::{self, html, html_to, Render};
+
+#[test]
+fn html_render_to_buffer() {
+    let mut buf = String::new();
+
+    html_to! { buf 
+        p { "existing" }
+    };
+    
+    assert_eq!(buf, "<p>existing</p>");
+}
+
+#[test]
+fn html_buffer_reuse() {
+    let mut buf = String::new();
+    html_to! { buf 
+        p { "existing" }
+    };
+    
+    html_to! { buf 
+        p { "reused" }
+    };
+    
+    assert_eq!(buf, "<p>existing</p><p>reused</p>");
+}
+
+#[test]
+fn impl_render_to_html_to() {
+    struct Foo;
+    impl Render for Foo {
+        fn render_to(&self, buffer: &mut String) {
+            html_to! { buffer
+                a { "foobar" }                
+            }
+        }
+    }
+
+    let rendered = html! {
+        p { (Foo) }
+    }.into_string();
+    
+    assert_eq!(rendered, "<p><a>foobar</a></p>");
+}

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -11,7 +11,7 @@ mod generate;
 mod parse;
 
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
-use proc_macro_error::proc_macro_error;
+use proc_macro_error::{proc_macro_error, abort};
 use quote::quote;
 
 #[proc_macro]
@@ -20,18 +20,47 @@ pub fn html(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     expand(input.into()).into()
 }
 
+#[proc_macro]
+#[proc_macro_error]
+pub fn html_to(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    expand_to(input.into()).into()
+}
+
 fn expand(input: TokenStream) -> TokenStream {
-    let output_ident = TokenTree::Ident(Ident::new("__maud_output", Span::mixed_site()));
-    // Heuristic: the size of the resulting markup tends to correlate with the
-    // code size of the template itself
-    let size_hint = input.to_string().len();
-    let markups = parse::parse(input);
-    let stmts = generate::generate(markups, output_ident.clone());
     quote!({
         extern crate alloc;
         extern crate maud;
-        let mut #output_ident = alloc::string::String::with_capacity(#size_hint);
+        let mut __maud_output = alloc::string::String::new();
+        maud::html_to!(__maud_output #input);
+        maud::PreEscaped(__maud_output)
+    })
+}
+
+fn expand_to(input: TokenStream) -> TokenStream {
+    // TODO: Better/more beatiful way to get ident? 
+    let mut iter = input.clone().into_iter();
+
+    // TODO: Better place for error handling?
+    let output_ident = match iter.next() {
+        Some(ident @ TokenTree::Ident(_)) => ident,
+        Some(token) => abort!(
+            token,
+            "expected mutable String buffer",
+        ),
+        None => abort!(
+            input,
+            "expected mutable String buffer"
+        ),
+    };
+    
+    // Heuristic: the size of the resulting markup tends to correlate with the
+    // code size of the template itself
+    let size_hint = input.to_string().len();
+    let markups = parse::parse(iter.collect());
+    let stmts = generate::generate(markups, output_ident.clone());
+    quote!({
+        extern crate maud;
+        #output_ident.reserve(#size_hint);
         #stmts
-        maud::PreEscaped(#output_ident)
     })
 }


### PR DESCRIPTION
Another attempt to add feature requested in #90.
This PR add `html_to!` macro that can use existing String as output buffer.
Example:
```rust
use maud::{self, html, html_to, Render};

#[test]
fn html_render_to_buffer() {
    let mut buf = String::new();

    html_to! { buf 
        p { "existing" }
    };
    
    assert_eq!(buf, "<p>existing</p>");
}

#[test]
fn html_buffer_reuse() {
    let mut buf = String::new();
    html_to! { buf 
        p { "existing" }
    };
    
    html_to! { buf 
        p { "reused" }
    };
    
    assert_eq!(buf, "<p>existing</p><p>reused</p>");
}

#[test]
fn impl_render_to_html_to() {
    struct Foo;
    impl Render for Foo {
        fn render_to(&self, buffer: &mut String) {

            html_to! { buffer
                a { "foobar" }                
            }
        }
    }

    let rendered = html! {
        p { (Foo) }
    }.into_string();
    
    assert_eq!(rendered, "<p><a>foobar</a></p>");
}
```

I'm requesting comments on how to improve this and fit it better into existing code