### PR TITLE
Parse many literals along side idents in names

### DIFF
--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -201,10 +201,10 @@ fn raw_string_literals_in_attribute_names() {
 
 #[test]
 fn other_literals_in_attribute_names() {
-    let result = html! { this r#"byte_string"#="false" 123="123" 123usize "2.5" true of-course {} };
+    let result = html! { this r#"raw_string"#="false" 123="123" 123usize "2.5" true of-course {} };
     assert_eq!(
         result.into_string(),
-        r#"<this byte_string="false" 123="123" 123usize 2.5 true of-course></this>"#
+        r#"<this raw_string="false" 123="123" 123usize 2.5 true of-course></this>"#
     );
 }
 

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -210,6 +210,15 @@ fn other_literals_in_attribute_names() {
 }
 
 #[test]
+fn idents_and_literals_in_names() {
+    let result = html! { custom:element-001 test:123-"test"="123" .m-2.p-2 {} };
+    assert_eq!(
+        result.into_string(),
+        r#"<custom:element-001 class="m-2 p-2" test:123-test="123"></custom:element-001>"#
+    );
+}
+
+#[test]
 fn class_shorthand() {
     let result = html! { p { "Hi, " span.name { "Lyra" } "!" } };
     assert_eq!(

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -201,11 +201,10 @@ fn raw_string_literals_in_attribute_names() {
 
 #[test]
 fn other_literals_in_attribute_names() {
-    let result =
-        html! { this b"byte_string"="false" 123="123" 2.5 true 'a'="a" b'b'="b" of-course {} };
+    let result = html! { this r#"byte_string"#="false" 123="123" "2.5" true of-course {} };
     assert_eq!(
         result.into_string(),
-        r#"<this byte_string="false" 123="123" 2.5 true a="a" b="b" of-course></this>"#
+        r#"<this byte_string="false" 123="123" 2.5 true of-course></this>"#
     );
 }
 

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -201,10 +201,10 @@ fn raw_string_literals_in_attribute_names() {
 
 #[test]
 fn other_literals_in_attribute_names() {
-    let result = html! { this r#"byte_string"#="false" 123="123" "2.5" true of-course {} };
+    let result = html! { this r#"byte_string"#="false" 123="123" 123usize "2.5" true of-course {} };
     assert_eq!(
         result.into_string(),
-        r#"<this byte_string="false" 123="123" 2.5 true of-course></this>"#
+        r#"<this byte_string="false" 123="123" 123usize 2.5 true of-course></this>"#
     );
 }
 

--- a/maud/tests/warnings/non-string-literal.stderr
+++ b/maud/tests/warnings/non-string-literal.stderr
@@ -1,53 +1,43 @@
-error: literal must be double-quoted: `"42"`
- --> $DIR/non-string-literal.rs:5:9
-  |
-5 |         42
-  |         ^^
-
-error: literal must be double-quoted: `"42usize"`
- --> $DIR/non-string-literal.rs:6:9
-  |
-6 |         42usize
-  |         ^^^^^^^
-
 error: literal must be double-quoted: `"42.0"`
- --> $DIR/non-string-literal.rs:7:9
+ --> tests/warnings/non-string-literal.rs:7:9
   |
 7 |         42.0
   |         ^^^^
 
 error: literal must be double-quoted: `"a"`
- --> $DIR/non-string-literal.rs:8:9
+ --> tests/warnings/non-string-literal.rs:8:9
   |
 8 |         'a'
   |         ^^^
 
 error: expected string
- --> $DIR/non-string-literal.rs:9:9
+ --> tests/warnings/non-string-literal.rs:9:9
   |
 9 |         b"a"
   |         ^^^^
 
 error: expected string
-  --> $DIR/non-string-literal.rs:10:9
+  --> tests/warnings/non-string-literal.rs:10:9
    |
 10 |         b'a'
    |         ^^^^
 
 error: attribute value must be a string
-  --> $DIR/non-string-literal.rs:13:24
+
+         = help: to declare an empty attribute, omit the equals sign: `disabled`
+         = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
+
+  --> tests/warnings/non-string-literal.rs:13:24
    |
 13 |         input disabled=true;
    |                        ^^^^
-   |
-   = help: to declare an empty attribute, omit the equals sign: `disabled`
-   = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
 
 error: attribute value must be a string
-  --> $DIR/non-string-literal.rs:14:24
+
+         = help: to declare an empty attribute, omit the equals sign: `disabled`
+         = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
+
+  --> tests/warnings/non-string-literal.rs:14:24
    |
 14 |         input disabled=false;
    |                        ^^^^^
-   |
-   = help: to declare an empty attribute, omit the equals sign: `disabled`
-   = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`

--- a/maud/tests/warnings/non-string-literal.stderr
+++ b/maud/tests/warnings/non-string-literal.stderr
@@ -23,21 +23,19 @@ error: expected string
    |         ^^^^
 
 error: attribute value must be a string
-
-         = help: to declare an empty attribute, omit the equals sign: `disabled`
-         = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
-
   --> tests/warnings/non-string-literal.rs:13:24
    |
 13 |         input disabled=true;
    |                        ^^^^
+   |
+   = help: to declare an empty attribute, omit the equals sign: `disabled`
+   = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
 
 error: attribute value must be a string
-
-         = help: to declare an empty attribute, omit the equals sign: `disabled`
-         = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
-
   --> tests/warnings/non-string-literal.rs:14:24
    |
 14 |         input disabled=false;
    |                        ^^^^^
+   |
+   = help: to declare an empty attribute, omit the equals sign: `disabled`
+   = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -204,7 +204,13 @@ impl Parser {
             }
             // Boolean literals are idents, so `Lit::Bool` is handled in
             // `markup`, not here.
-            Lit::Int(..) | Lit::Float(..) => {
+            Lit::Int(lit_int) => {
+                return ast::Markup::Literal {
+                    content: lit_int.to_string(),
+                    span: SpanRange::single_span(literal.span()),
+                };
+            }
+            Lit::Float(..) => {
                 emit_error!(literal, r#"literal must be double-quoted: `"{}"`"#, literal);
             }
             Lit::Char(lit_char) => {

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -716,11 +716,15 @@ impl Parser {
                     result.push(TokenTree::Punct(punct.clone()));
                     true
                 }
-                Some(token @ TokenTree::Ident(_)) | Some(token @ TokenTree::Literal(_))
-                    if expect_ident_or_literal =>
-                {
+                Some(token @ TokenTree::Ident(_)) if expect_ident_or_literal => {
                     self.advance();
                     result.push(token);
+                    false
+                }
+                Some(TokenTree::Literal(ref literal)) if expect_ident_or_literal => {
+                    self.literal(literal.clone());
+                    self.advance();
+                    result.push(TokenTree::Literal(literal.clone()));
                     false
                 }
                 _ => {

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -702,27 +702,28 @@ impl Parser {
     /// Parses an identifier, without dealing with namespaces.
     fn try_name(&mut self) -> Option<TokenStream> {
         let mut result = Vec::new();
-        match self.peek() {
-            Some(token @ TokenTree::Ident(_)) | Some(token @ TokenTree::Literal(_)) => {
-                self.advance();
-                result.push(token);
-            }
-            _ => return None,
-        };
-        let mut expect_ident = false;
+        let mut expect_ident_or_literal = true;
         loop {
-            expect_ident = match self.peek() {
+            expect_ident_or_literal = match self.peek() {
                 Some(TokenTree::Punct(ref punct)) if punct.as_char() == '-' => {
                     self.advance();
                     result.push(TokenTree::Punct(punct.clone()));
                     true
                 }
-                Some(TokenTree::Ident(ref ident)) if expect_ident => {
+                Some(token @ TokenTree::Ident(_)) | Some(token @ TokenTree::Literal(_))
+                    if expect_ident_or_literal =>
+                {
                     self.advance();
-                    result.push(TokenTree::Ident(ident.clone()));
+                    result.push(token);
                     false
                 }
-                _ => break,
+                _ => {
+                    if result.is_empty() {
+                        return None;
+                    } else {
+                        break;
+                    }
+                }
             };
         }
         Some(result.into_iter().collect())


### PR DESCRIPTION
This is a fix for the bug mentioned in https://github.com/lambda-fairy/maud/pull/396#issuecomment-1811008846. 

This is similar to #336 and also addresses #335, se the test for examples of what is now possible

The implications mentioned in https://github.com/lambda-fairy/maud/issues/335#issuecomment-1094247196 are not addressed here, but for now this fixes the bug that #396 created