### PR TITLE
Upgrade to `syn` 2.0.0

### DIFF
--- a/docs/Cargo.lock
+++ b/docs/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -257,7 +257,6 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
  "version_check",
 ]
 
@@ -357,7 +356,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn",
 ]
 
 [[package]]
@@ -378,17 +377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373"
 dependencies = [
  "deunicode",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -442,7 +430,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn",
 ]
 
 [[package]]

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -11,7 +11,7 @@ description = "Compile-time HTML templates."
 edition = "2021"
 
 [dependencies]
-syn = "1.0.8"
+syn = "2"
 quote = "1.0.7"
 proc-macro2 = "1.0.23"
 proc-macro-error = "1.0.0"

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 syn = "2"
 quote = "1.0.7"
 proc-macro2 = "1.0.23"
-proc-macro-error = "1.0.0"
+proc-macro-error = { version = "1.0.0", default-features = false }
 
 [lib]
 name = "maud_macros"


### PR DESCRIPTION
This PR bumps the `syn` dependency to version 2.0.0

It also removes the default features of `proc-macro-error` (which weren't used) to remove the transitive dependency on `syn` 1.0.0.