### PR TITLE
Warp Integration: Yet another web framework support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Accept literals in attribute names
   [#396](https://github.com/lambda-fairy/maud/pull/396)
 - Add support for `warp` v0.3.6
-  [#]()
+  [#404](https://github.com/lambda-fairy/maud/pull/404)
 
 ## [0.25.0] - 2023-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   [#380](https://github.com/lambda-fairy/maud/pull/380)
 - Accept literals in attribute names
   [#396](https://github.com/lambda-fairy/maud/pull/396)
+- Add support for `warp` v0.3.6
+  [#]()
 
 ## [0.25.0] - 2023-04-16
 

--- a/docs/content/web-frameworks.md
+++ b/docs/content/web-frameworks.md
@@ -7,6 +7,7 @@ Maud includes support for these web frameworks: [Actix], [Rocket], [Rouille], [T
 [Rouille]: https://github.com/tomaka/rouille
 [Tide]: https://docs.rs/tide/
 [Axum]: https://docs.rs/axum/
+[Warp]: https://seanmonstar.com/blog/warp/
 
 # Actix
 
@@ -171,5 +172,30 @@ async fn main() {
         .serve(app.into_make_service())
         .await
         .unwrap();
+}
+```
+
+# Warp
+
+Warp support is available with the "warp" feature:
+
+```toml
+# ...
+[dependencies]
+maud = { version = "*", features = ["warp"] }
+# ...
+```
+
+This enables `Markup` to be of type `warp::Reply`, making it possible to return it
+immediately from a handler.
+
+```rust,no_run
+use maud::html;
+use warp::Filter;
+
+#[tokio::main]
+async fn main() {
+    let hello = warp::any().map(|| html! { h1 { "Hello, world!" } });
+    warp::serve(hello).run(([127, 0, 0, 1], 8000)).await;
 }
 ```

--- a/doctest/Cargo.toml
+++ b/doctest/Cargo.toml
@@ -14,6 +14,7 @@ rouille = "3"
 tide = "0.16"
 tokio = { version = "1.9.0", features = ["rt", "macros", "rt-multi-thread"] }
 axum = "0.6"
+warp = "0.3.6"
 
 [dependencies.async-std]
 version = "1.9.0"

--- a/doctest/Cargo.toml
+++ b/doctest/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 actix-web = { version = "4.0.0-rc.2", default-features = false, features = ["macros"] }
 ammonia = "3"
-maud = { path = "../maud", features = ["actix-web", "rocket", "tide", "axum"] }
+maud = { path = "../maud", features = ["actix-web", "rocket", "tide", "axum", "warp"] }
 pulldown-cmark = "0.8"
 rocket = "0.4"
 rouille = "3"

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -27,6 +27,7 @@ actix-web-dep = { package = "actix-web", version = "4", optional = true, default
 tide = { version = "0.16.0", optional = true, default-features = false }
 axum-core = { version = "0.3", optional = true }
 http = { version = "0.2", optional = true }
+warp = { version = "0.3.6", optional = true }
 
 [dev-dependencies]
 trybuild = { version = "1.0.33", features = ["diff"] }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -353,6 +353,19 @@ mod axum_support {
     }
 }
 
+#[cfg(feature = "warp")]
+mod warp_support {
+    use crate::PreEscaped;
+    use alloc::string::String;
+    use warp::reply::{self, Response, Reply};
+
+    impl Reply for PreEscaped<String> {
+        fn into_response(self) -> Response {
+            reply::html(self.into_string()).into_response()
+        }
+    }
+}
+
 #[doc(hidden)]
 pub mod macro_private {
     use crate::{display, Render};

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -357,7 +357,7 @@ mod axum_support {
 mod warp_support {
     use crate::PreEscaped;
     use alloc::string::String;
-    use warp::reply::{self, Response, Reply};
+    use warp::reply::{self, Reply, Response};
 
     impl Reply for PreEscaped<String> {
         fn into_response(self) -> Response {


### PR DESCRIPTION
This implements `warp::Reply` for `Markup`, making it possible to return it from a handler and making *maud* more pleasing to use with *warp*.