### PR TITLE
Support attribute spreading with iterators

### DIFF
--- a/maud/tests/misc.rs
+++ b/maud/tests/misc.rs
@@ -152,4 +152,8 @@ fn dynamic_attr() {
         html! { p (..)=[attrs] {} }.into_string(),
         r#"<p id="foo" class="bar"></p>"#
     );
+    assert_eq!(
+        html! { p (..)=[[("id", "foo2"), ("class", "bar2")]] {} }.into_string(),
+        r#"<p id="foo2" class="bar2"></p>"#
+    );
 }

--- a/maud/tests/misc.rs
+++ b/maud/tests/misc.rs
@@ -143,3 +143,13 @@ fn render_arc() {
     let arc = std::sync::Arc::new("foo");
     assert_eq!(html! { (arc) }.into_string(), "foo");
 }
+
+#[test]
+fn dynamic_attr() {
+    let attrs = [("id", "foo"), ("class", "bar")];
+
+    assert_eq!(
+        html! { p (..)=[attrs] {} }.into_string(),
+        r#"<p id="foo" class="bar"></p>"#
+    );
+}

--- a/maud/tests/misc.rs
+++ b/maud/tests/misc.rs
@@ -153,7 +153,7 @@ fn dynamic_attr() {
         r#"<p id="foo" class="bar"></p>"#
     );
     assert_eq!(
-        html! { p (..)=[[("id", "foo2"), ("class", "bar2")]] {} }.into_string(),
+        html! { p (..)=[[("id", 1), ("class", 2)]] {} }.into_string(),
         r#"<p id="foo2" class="bar2"></p>"#
     );
 }

--- a/maud/tests/misc.rs
+++ b/maud/tests/misc.rs
@@ -154,6 +154,6 @@ fn dynamic_attr() {
     );
     assert_eq!(
         html! { p (..)=[[("id", 1), ("class", 2)]] {} }.into_string(),
-        r#"<p id="foo2" class="bar2"></p>"#
+        r#"<p id="1" class="2"></p>"#
     );
 }

--- a/maud_macros/src/ast.rs
+++ b/maud_macros/src/ast.rs
@@ -80,6 +80,9 @@ pub enum Attr {
     Named {
         named_attr: NamedAttr,
     },
+    Dynamic {
+        dyn_attr: DynAttr,
+    },
 }
 
 impl Attr {
@@ -106,6 +109,7 @@ impl Attr {
                 hash_span.join_range(name_span)
             }
             Attr::Named { ref named_attr } => named_attr.span(),
+            Attr::Dynamic { ref dyn_attr } => dyn_attr.span(),
         }
     }
 }
@@ -151,6 +155,11 @@ impl Special {
     }
 }
 
+pub enum EitherAttr {
+    Named(NamedAttr),
+    Dynamic(DynAttr),
+}
+
 #[derive(Debug)]
 pub struct NamedAttr {
     pub name: TokenStream,
@@ -165,6 +174,19 @@ impl NamedAttr {
         } else {
             name_span
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct DynAttr {
+    pub paren_span: SpanRange,
+    pub expr: TokenStream,
+}
+
+impl DynAttr {
+    fn span(&self) -> SpanRange {
+        let expr_span = span_tokens(self.expr.clone());
+        self.paren_span.join_range(expr_span)
     }
 }
 

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -131,7 +131,7 @@ impl Generator {
                     let tokens = quote! {
                         for (key, value) in #expr {
                             #output.push_str(" ");
-                            #output.push_str(key);
+                            #output.push_str(&key.to_string());
                             #output.push_str("=\"");
                             // Not sure if this should be escaped or not
                             #output.push_str(&value.to_string());

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -134,7 +134,7 @@ impl Generator {
                             #output.push_str(key);
                             #output.push_str("=\"");
                             // Not sure if this should be escaped or not
-                            #output.push_str(value);
+                            #output.push_str(&value.to_string());
                             #output.push_str("\"");
                         }
                     };

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -133,6 +133,7 @@ impl Generator {
                             #output.push_str(" ");
                             #output.push_str(key);
                             #output.push_str("=\"");
+                            // Not sure if this should be escaped or not
                             #output.push_str(value);
                             #output.push_str("\"");
                         }

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -640,15 +640,14 @@ impl Parser {
                         if paran_group.delimiter() == Delimiter::Parenthesis
                             && paran_group.stream().to_string() == ".." =>
                     {
-                        self.advance();
                         // Check `=` follows directly after `(..)`
-                        if let Some(TokenTree::Punct(ref punct)) = self.peek() {
+                        if let Some((_, Some(TokenTree::Punct(ref punct)))) = self.peek2() {
                             if punct.as_char() == '=' {
                                 self.advance();
                                 // Check for `[expr]`
-                                if let Some(TokenTree::Group(group)) = self.peek() {
+                                if let Some((_, Some(TokenTree::Group(group)))) = self.peek2() {
                                     if group.delimiter() == Delimiter::Bracket {
-                                        self.advance();
+                                        self.advance2();
                                         attrs.push(ast::Attr::Dynamic {
                                             dyn_attr: ast::DynAttr {
                                                 paren_span: SpanRange::single_span(

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -663,7 +663,8 @@ impl Parser {
                         }
                         // If we get here, the syntax was not correctly followed by `=`
                         break;
-                    } // If it's not a valid attribute, backtrack and bail out
+                    }
+                    // If it's not a valid attribute, backtrack and bail out
                     _ => break,
                 }
             }


### PR DESCRIPTION
This PR adds the ability to spread attributes using iterators (#386, #240).

The syntax is as following:

`(..)=[attrs]` Where `attrs` is an expression that supports any iterator with tuples where the name and value implements `Display`.