### PR TITLE
Axum API change

### DIFF
--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -25,8 +25,8 @@ rocket = { version = ">= 0.3, < 0.5", optional = true }
 futures-util = { version = "0.3.0", optional = true, default-features = false }
 actix-web-dep = { package = "actix-web", version = "4", optional = true, default-features = false }
 tide = { version = "0.16.0", optional = true, default-features = false }
-axum-core = { version = "0.3", optional = true }
-http = { version = "0.2", optional = true }
+axum-core = { version = "0.4.1", optional = true }
+http = { version = "1.0", optional = true }
 
 [dev-dependencies]
 trybuild = { version = "1.0.33", features = ["diff"] }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -338,11 +338,11 @@ mod tide_support {
 mod axum_support {
     use crate::PreEscaped;
     use alloc::string::String;
-    use axum_core::{body::BoxBody, response::IntoResponse};
+    use axum_core::{body::Body, response::IntoResponse};
     use http::{header, HeaderMap, HeaderValue, Response};
 
     impl IntoResponse for PreEscaped<String> {
-        fn into_response(self) -> Response<BoxBody> {
+        fn into_response(self) -> Response<Body> {
             let mut headers = HeaderMap::new();
             headers.insert(
                 header::CONTENT_TYPE,


### PR DESCRIPTION
Axum-core and HTTP API have slightly changed for one of the latest Axum releases and the intoResponse trait was no longer satisfied. This fix works again for the latest release of Axum, but the author of this library might choose to support the older API as well. The public API of Maud is not affected by this fix.