### PR TITLE
Disallow int literals in attribute values

### DIFF
--- a/maud/tests/warnings/non-string-literal.stderr
+++ b/maud/tests/warnings/non-string-literal.stderr
@@ -1,3 +1,15 @@
+error: literal must be double-quoted: `"42"`
+ --> tests/warnings/non-string-literal.rs:5:9
+  |
+5 |         42
+  |         ^^
+
+error: literal must be double-quoted: `"42usize"`
+ --> tests/warnings/non-string-literal.rs:6:9
+  |
+6 |         42usize
+  |         ^^^^^^^
+
 error: literal must be double-quoted: `"42.0"`
  --> tests/warnings/non-string-literal.rs:7:9
   |

--- a/maud_macros/src/ast.rs
+++ b/maud_macros/src/ast.rs
@@ -223,11 +223,6 @@ pub fn name_to_string(name: TokenStream) -> String {
             if let TokenTree::Literal(literal) = token {
                 match Lit::new(literal.clone()) {
                     Lit::Str(str) => str.value(),
-                    Lit::Char(char) => char.value().to_string(),
-                    Lit::ByteStr(byte) => {
-                        String::from_utf8(byte.value()).expect("Invalid utf8 byte")
-                    }
-                    Lit::Byte(byte) => (byte.value() as char).to_string(),
                     _ => literal.to_string(),
                 }
             } else {


### PR DESCRIPTION
Allowing int literals in attribute values is potentially confusing, as `foo=123usize` is allowed but `foo=usize123` is not.

Int literals in attribute _names_ are still useful for htmx (e.g. [`hx-target-404`](https://htmx.org/extensions/response-targets/)) so we continue allowing that.