### PR TITLE
Switch to proc_macro_error2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Switch to `proc_macro_error2`
+  [#441](https://github.com/lambda-fairy/maud/issues/441)
+  [#442](https://github.com/lambda-fairy/maud/pull/442)
+
 ## [0.26.0] - 2024-01-15
 
 - Remove `AsRef<str>` restriction from `PreEscaped`

--- a/docs/Cargo.lock
+++ b/docs/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 name = "maud_macros"
 version = "0.26.0"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -379,26 +379,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
 ]
 
 [[package]]
@@ -652,12 +650,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/maud/tests/warnings/keyword-without-at.stderr
+++ b/maud/tests/warnings/keyword-without-at.stderr
@@ -1,7 +1,8 @@
 error: found keyword `if`
+
+         = help: should this be a `@if`?
+
  --> $DIR/keyword-without-at.rs:5:9
   |
 5 |         if {}
   |         ^^
-  |
-  = help: should this be a `@if`?

--- a/maud/tests/warnings/non-string-literal.stderr
+++ b/maud/tests/warnings/non-string-literal.stderr
@@ -35,19 +35,21 @@ error: expected string
    |         ^^^^
 
 error: attribute value must be a string
+
+         = help: to declare an empty attribute, omit the equals sign: `disabled`
+         = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
+
   --> tests/warnings/non-string-literal.rs:13:24
    |
 13 |         input disabled=true;
    |                        ^^^^
-   |
-   = help: to declare an empty attribute, omit the equals sign: `disabled`
-   = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
 
 error: attribute value must be a string
+
+         = help: to declare an empty attribute, omit the equals sign: `disabled`
+         = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
+
   --> tests/warnings/non-string-literal.rs:14:24
    |
 14 |         input disabled=false;
    |                        ^^^^^
-   |
-   = help: to declare an empty attribute, omit the equals sign: `disabled`
-   = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`

--- a/maud/tests/warnings/void-element-slash.stderr
+++ b/maud/tests/warnings/void-element-slash.stderr
@@ -1,17 +1,19 @@
 error: void elements must use `;`, not `/`
+
+         = help: change this to `;`
+         = help: see https://github.com/lambda-fairy/maud/pull/315 for details
+
  --> $DIR/void-element-slash.rs:5:12
   |
 5 |         br /
   |            ^
-  |
-  = help: change this to `;`
-  = help: see https://github.com/lambda-fairy/maud/pull/315 for details
 
 error: void elements must use `;`, not `/`
+
+         = help: change this to `;`
+         = help: see https://github.com/lambda-fairy/maud/pull/315 for details
+
  --> $DIR/void-element-slash.rs:7:27
   |
 7 |         input type="text" /
   |                           ^
-  |
-  = help: change this to `;`
-  = help: see https://github.com/lambda-fairy/maud/pull/315 for details

--- a/maud_macros/Cargo.toml
+++ b/maud_macros/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 syn = "2"
 quote = "1.0.7"
 proc-macro2 = "1.0.23"
-proc-macro-error = { version = "1.0.0", default-features = false }
+proc-macro-error2 = { version = "2.0.1", default-features = false }
 
 [lib]
 name = "maud_macros"

--- a/maud_macros/src/ast.rs
+++ b/maud_macros/src/ast.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{TokenStream, TokenTree};
-use proc_macro_error::SpanRange;
+use proc_macro_error2::SpanRange;
 use syn::Lit;
 
 #[derive(Debug)]

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Delimiter, Group, Ident, Literal, Span, TokenStream, TokenTree};
-use proc_macro_error::SpanRange;
+use proc_macro_error2::SpanRange;
 use quote::quote;
 
 use crate::{ast::*, escape};

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -11,7 +11,7 @@ mod generate;
 mod parse;
 
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
-use proc_macro_error::proc_macro_error;
+use proc_macro_error2::proc_macro_error;
 use quote::quote;
 
 #[proc_macro]

--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Delimiter, Ident, Literal, Spacing, Span, TokenStream, TokenTree};
-use proc_macro_error::{abort, abort_call_site, emit_error, SpanRange};
+use proc_macro_error2::{abort, abort_call_site, emit_error, SpanRange};
 use std::collections::HashMap;
 
 use syn::Lit;


### PR DESCRIPTION
Fixes #441.

`proc_macro_error` is marked as unmaintained in rustsec: https://rustsec.org/advisories/RUSTSEC-2024-0370.html

Because `proc_macro_error2` removed automatic nightly detection, the error messages changed slightly.