### PR TITLE
Added: Render for Option<T>

### DIFF
--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -156,14 +156,10 @@ impl<T: Render + ?Sized> Render for Arc<T> {
     }
 }
 
-impl<T: Render + ?Sized> Render for Option<T> {
-    fn render_to(&self, w: &mut String) { if let Some(inner) = self { T::render_to(inner, w); } }
-}
-
-impl <T: Render + ?Sized, I: ExactSizeIterator + ?Sized> Render for I where I::Item: AsRef<T> {
+impl<T: Render> Render for Option<T> {
     fn render_to(&self, w: &mut String) {
-        for item in self {
-            item.as_ref().render_to(w);
+        if let Some(inner) = self {
+            T::render_to(inner, w);
         }
     }
 }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -156,6 +156,18 @@ impl<T: Render + ?Sized> Render for Arc<T> {
     }
 }
 
+impl<T: Render + ?Sized> Render for Option<T> {
+    fn render_to(&self, w: &mut String) { if let Some(inner) = self { T::render_to(inner, w); } }
+}
+
+impl <T: Render + ?Sized, I: ExactSizeIterator + ?Sized> Render for I where I::Item: AsRef<T> {
+    fn render_to(&self, w: &mut String) {
+        for item in self {
+            item.as_ref().render_to(w);
+        }
+    }
+}
+
 macro_rules! impl_render_with_display {
     ($($ty:ty)*) => {
         $(


### PR DESCRIPTION
```rust
impl<T: Render + ?Sized> Render for Option<T> {
    fn render_to(&self, w: &mut String) { if let Some(inner) = self { T::render_to(inner, w); } }
}

impl <T: Render + ?Sized, I: ExactSizeIterator + ?Sized> Render for I where I::Item: AsRef<T> {
    fn render_to(&self, w: &mut String) {
        for item in self {
            item.as_ref().render_to(w);
        }
    }
}
```

Implemented Render for 2 types:
- `ExactSizeIterator` since if it was infinite like: `0..` it would run forever. ( Not 100% sure if this implementation works, if anyone could tell me how i can test this it would be much appreciated since you dont need a owned value to render it. ergo `AsRef<T>` for `I::Item`)
- `Option<T>` Simple, if self is some render the inner value if not, dont render it. ( I think thats how @martinhath wanted it to work. )

If there are any suggestions for other types to implement or if my implementation has issues ill gladly fix them.

