### PR TITLE
Abort when `else` is used without `@` (#449)

### DIFF
--- a/maud_macros/src/parse.rs
+++ b/maud_macros/src/parse.rs
@@ -137,7 +137,7 @@ impl Parser {
             TokenTree::Ident(ident) => {
                 let ident_string = ident.to_string();
                 match ident_string.as_str() {
-                    "if" | "while" | "for" | "match" | "let" => {
+                    "if" | "while" | "for" | "match" | "let" | "else" => {
                         abort!(
                             ident,
                             "found keyword `{}`", ident_string;


### PR DESCRIPTION
Fixes #449.