### PR TITLE
Introducing feature 'alloc' that removes dependency of alloc::sync::Arc

### DIFF
--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -14,6 +14,7 @@ edition.workspace = true
 
 [features]
 default = []
+alloc = []
 
 # Web framework integrations
 actix-web = ["actix-web-dep", "futures-util"]

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -15,6 +15,7 @@ edition.workspace = true
 [features]
 default = []
 alloc = []
+picoserve = ["dep:picoserve"]
 
 # Web framework integrations
 actix-web = ["actix-web-dep", "futures-util"]
@@ -31,6 +32,7 @@ axum-core = { version = "0.4", optional = true }
 submillisecond = { version = "0.4.1", optional = true }
 http = { version = "1", optional = true }
 warp = { version = "0.3.6", optional = true }
+picoserve = { version = ">=0.13.3", optional = true }
 
 [dev-dependencies]
 trybuild = { version = "1.0.33", features = ["diff"] }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -11,7 +11,11 @@
 
 extern crate alloc;
 
-use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc};
+use alloc::{borrow::Cow, boxed::Box, string::String};
+
+#[cfg(not(feature = "alloc"))]
+use alloc::sync::Arc;
+
 use core::fmt::{self, Arguments, Display, Write};
 
 pub use maud_macros::html;
@@ -150,6 +154,7 @@ impl<T: Render + ?Sized> Render for Box<T> {
     }
 }
 
+#[cfg(not(feature = "alloc"))]
 impl<T: Render + ?Sized> Render for Arc<T> {
     fn render_to(&self, w: &mut String) {
         T::render_to(self, w);

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -383,6 +383,26 @@ mod axum_support {
     }
 }
 
+#[cfg(feature = "picoserve")]
+mod picoserve_support {
+    use crate::Markup;
+    use picoserve::{response::{Content}, io::Write};
+
+    impl Content for Markup {
+        fn content_type(&self) -> &'static str {
+            "text/html; charset=utf-8"
+        }
+
+        fn content_length(&self) -> usize {
+            self.0.len()
+        }
+
+        async fn write_content<W: Write>(self, writer: W) -> Result<(), W::Error> {
+            self.0.clone().write_content(writer).await
+        }
+    }
+}
+
 #[cfg(feature = "warp")]
 mod warp_support {
     use crate::PreEscaped;


### PR DESCRIPTION
The naming might be off here -- didn't really know a better feature name.

I'm using Maud for esp no_std development, and the esp-alloc crate I use there, does not have sync::Arc -- so I made a feature in Maud called 'alloc' (perhaps it should be called 'esp-alloc'?) that when enabled, will have Maud skip support for sync::Arc. Works great so far :-)