### PR TITLE
Bump axum-core to 0.5 for axum 0.8 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Support `axum` v0.8 through `axum-core` v0.5
+
 ## [0.26.0] - 2024-01-15
 
 - Remove `AsRef<str>` restriction from `PreEscaped`

--- a/doctest/Cargo.toml
+++ b/doctest/Cargo.toml
@@ -14,7 +14,7 @@ rouille = "3"
 submillisecond = "0.4.1"
 tide = "0.16"
 tokio = { version = "1.9.0", features = ["rt", "macros", "rt-multi-thread"] }
-axum = "0.7"
+axum = "0.8"
 warp = "0.3.6"
 
 [dependencies.async-std]

--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -26,7 +26,7 @@ rocket = { version = "0.5", optional = true }
 futures-util = { version = "0.3.0", optional = true, default-features = false }
 actix-web-dep = { package = "actix-web", version = "4", optional = true, default-features = false }
 tide = { version = "0.16.0", optional = true, default-features = false }
-axum-core = { version = "0.4", optional = true }
+axum-core = { version = "0.5", optional = true }
 submillisecond = { version = "0.4.1", optional = true }
 http = { version = "1", optional = true }
 warp = { version = "0.3.6", optional = true }


### PR DESCRIPTION
axum 0.8 uses axum-core 0.5, which is not semver-compatible with 0.4 and thus doesn't get picked up.

Not sure if there's more to do.

Fixes #453