### PR TITLE
Disallow elements in attributes

### DIFF
--- a/maud/tests/warnings/element-in-attribute.rs
+++ b/maud/tests/warnings/element-in-attribute.rs
@@ -2,20 +2,29 @@ use maud::html;
 
 fn main() {
     html! {
-        a href={ div {} } {}
-    };
+        a href={ b {} } {}
 
-    html! {
-        a .{ div {} } {}
-    };
+        a .{ b {} } {}
+        a #{ b {} } {}
 
-    html! {
-        a #{ div {} } {}
-    };
-
-    html! {
         @if true {
-            a href={ div {} } {}
+            a href={ b #if {} } {}
+        } @else if true {
+            a href={ b #else-if {} } {}
+        } @else {
+            a href={ b #else {} } {}
+        }
+
+        @for _ in 0..10 {
+            a href={ b #for {} } {}
+        }
+
+        @while false {
+            a href={ b #while {} } {}
+        }
+
+        @match () {
+            () => a href={ b #match {} } {}
         }
     };
 }

--- a/maud/tests/warnings/element-in-attribute.rs
+++ b/maud/tests/warnings/element-in-attribute.rs
@@ -1,0 +1,21 @@
+use maud::html;
+
+fn main() {
+    html! {
+        a href={ div {} } {}
+    };
+
+    html! {
+        a .{ div {} } {}
+    };
+
+    html! {
+        a #{ div {} } {}
+    };
+
+    html! {
+        @if true {
+            a href={ div {} } {}
+        }
+    };
+}

--- a/maud/tests/warnings/element-in-attribute.stderr
+++ b/maud/tests/warnings/element-in-attribute.stderr
@@ -1,23 +1,53 @@
 error: cannot have element inside attribute
  --> tests/warnings/element-in-attribute.rs:5:18
   |
-5 |         a href={ div {} } {}
-  |                  ^^^^^^
+5 |         a href={ b {} } {}
+  |                  ^^^^
 
 error: cannot have element inside attribute
- --> tests/warnings/element-in-attribute.rs:9:14
+ --> tests/warnings/element-in-attribute.rs:7:14
   |
-9 |         a .{ div {} } {}
-  |              ^^^^^^
+7 |         a .{ b {} } {}
+  |              ^^^^
 
 error: cannot have element inside attribute
-  --> tests/warnings/element-in-attribute.rs:13:14
-   |
-13 |         a #{ div {} } {}
-   |              ^^^^^^
+ --> tests/warnings/element-in-attribute.rs:8:14
+  |
+8 |         a #{ b {} } {}
+  |              ^^^^
 
 error: cannot have element inside attribute
-  --> tests/warnings/element-in-attribute.rs:18:22
+  --> tests/warnings/element-in-attribute.rs:11:22
    |
-18 |             a href={ div {} } {}
-   |                      ^^^^^^
+11 |             a href={ b #if {} } {}
+   |                      ^^^^^^^^
+
+error: cannot have element inside attribute
+  --> tests/warnings/element-in-attribute.rs:13:22
+   |
+13 |             a href={ b #else-if {} } {}
+   |                      ^^^^^^^^^^^^^
+
+error: cannot have element inside attribute
+  --> tests/warnings/element-in-attribute.rs:15:22
+   |
+15 |             a href={ b #else {} } {}
+   |                      ^^^^^^^^^^
+
+error: cannot have element inside attribute
+  --> tests/warnings/element-in-attribute.rs:19:22
+   |
+19 |             a href={ b #for {} } {}
+   |                      ^^^^^^^^^
+
+error: cannot have element inside attribute
+  --> tests/warnings/element-in-attribute.rs:23:22
+   |
+23 |             a href={ b #while {} } {}
+   |                      ^^^^^^^^^^^
+
+error: cannot have element inside attribute
+  --> tests/warnings/element-in-attribute.rs:27:28
+   |
+27 |             () => a href={ b #match {} } {}
+   |                            ^^^^^^^^^^^

--- a/maud/tests/warnings/element-in-attribute.stderr
+++ b/maud/tests/warnings/element-in-attribute.stderr
@@ -1,0 +1,23 @@
+error: cannot have element inside attribute
+ --> tests/warnings/element-in-attribute.rs:5:18
+  |
+5 |         a href={ div {} } {}
+  |                  ^^^^^^
+
+error: cannot have element inside attribute
+ --> tests/warnings/element-in-attribute.rs:9:14
+  |
+9 |         a .{ div {} } {}
+  |              ^^^^^^
+
+error: cannot have element inside attribute
+  --> tests/warnings/element-in-attribute.rs:13:14
+   |
+13 |         a #{ div {} } {}
+   |              ^^^^^^
+
+error: cannot have element inside attribute
+  --> tests/warnings/element-in-attribute.rs:18:22
+   |
+18 |             a href={ div {} } {}
+   |                      ^^^^^^


### PR DESCRIPTION
Fixes a regression from #412.

The following code was allowed, and this PR fixes the parser to ban it:

```rust
html! {
    a href={ b {} } {}
}
```