### PR TITLE
Disallow elements in attributes (redux)

### DIFF
--- a/maud/tests/warnings/attribute-missing-value.stderr
+++ b/maud/tests/warnings/attribute-missing-value.stderr
@@ -1,5 +1,5 @@
-error: unexpected end of input, expected one of: curly braces, literal, parentheses, identifier, `.`, `#`, `@`, `;`
- --> $DIR/attribute-missing-value.rs:4:5
+error: unexpected end of input, expected one of: curly braces, literal, parentheses, `@`, `;`
+ --> tests/warnings/attribute-missing-value.rs:4:5
   |
 4 | /     html! {
 5 | |         a href=

--- a/maud/tests/warnings/class-shorthand-missing-value.stderr
+++ b/maud/tests/warnings/class-shorthand-missing-value.stderr
@@ -1,5 +1,5 @@
-error: unexpected end of input, expected one of: curly braces, literal, parentheses, identifier, `.`, `#`, `@`, `;`
- --> $DIR/class-shorthand-missing-value.rs:4:5
+error: unexpected end of input, expected one of: curly braces, literal, parentheses, `@`, `;`
+ --> tests/warnings/class-shorthand-missing-value.rs:4:5
   |
 4 | /     html! {
 5 | |         p.

--- a/maud/tests/warnings/elements-in-attributes.rs
+++ b/maud/tests/warnings/elements-in-attributes.rs
@@ -1,0 +1,45 @@
+use maud::html;
+
+fn main() {
+    html! {
+        a href={ b {} } {}
+    };
+
+    html! {
+        a href=.pinkie-pie {} {}
+    };
+
+    html! {
+        a .{ b {} } {}
+    };
+
+    html! {
+        a #{ b {} } {}
+    };
+
+    html! {
+        @if true {
+        } @else if true {
+        } @else {
+            a href={ b #if-else {} } {}
+        }
+    };
+
+    html! {
+        @for _ in 0..10 {
+            a href={ b #for {} } {}
+        }
+    };
+
+    html! {
+        @while false {
+            a href={ b #while {} } {}
+        }
+    };
+
+    html! {
+        @match () {
+            () => a href={ b #match {} } {}
+        }
+    };
+}

--- a/maud/tests/warnings/elements-in-attributes.stderr
+++ b/maud/tests/warnings/elements-in-attributes.stderr
@@ -1,0 +1,47 @@
+error: expected one of: curly braces, literal, parentheses, `@`, `;`
+ --> tests/warnings/elements-in-attributes.rs:5:18
+  |
+5 |         a href={ b {} } {}
+  |                  ^
+
+error: expected one of: curly braces, literal, parentheses, `@`, `;`
+ --> tests/warnings/elements-in-attributes.rs:9:16
+  |
+9 |         a href=.pinkie-pie {} {}
+  |                ^
+
+error: expected one of: curly braces, literal, parentheses, `@`, `;`
+  --> tests/warnings/elements-in-attributes.rs:13:14
+   |
+13 |         a .{ b {} } {}
+   |              ^
+
+error: expected one of: curly braces, literal, parentheses, `@`, `;`
+  --> tests/warnings/elements-in-attributes.rs:17:14
+   |
+17 |         a #{ b {} } {}
+   |              ^
+
+error: expected one of: curly braces, literal, parentheses, `@`, `;`
+  --> tests/warnings/elements-in-attributes.rs:24:22
+   |
+24 |             a href={ b #if-else {} } {}
+   |                      ^
+
+error: expected one of: curly braces, literal, parentheses, `@`, `;`
+  --> tests/warnings/elements-in-attributes.rs:30:22
+   |
+30 |             a href={ b #for {} } {}
+   |                      ^
+
+error: expected one of: curly braces, literal, parentheses, `@`, `;`
+  --> tests/warnings/elements-in-attributes.rs:36:22
+   |
+36 |             a href={ b #while {} } {}
+   |                      ^
+
+error: expected one of: curly braces, literal, parentheses, `@`, `;`
+  --> tests/warnings/elements-in-attributes.rs:42:28
+   |
+42 |             () => a href={ b #match {} } {}
+   |                            ^

--- a/maud_macros/src/ast.rs
+++ b/maud_macros/src/ast.rs
@@ -146,9 +146,6 @@ pub trait MaybeElement: Sized + ToTokens {
     fn should_parse(
         lookahead: &Lookahead1<'_>,
     ) -> Option<fn(ParseStream, &mut Vec<Diagnostic>) -> syn::Result<Self>>;
-
-    /// Converts the parsed result into an element.
-    fn into_element(self) -> Element;
 }
 
 /// Represents an attribute context, where elements are disallowed.
@@ -160,10 +157,6 @@ impl MaybeElement for NoElement {
         _lookahead: &Lookahead1<'_>,
     ) -> Option<fn(ParseStream, &mut Vec<Diagnostic>) -> syn::Result<Self>> {
         None
-    }
-
-    fn into_element(self) -> Element {
-        match self {}
     }
 }
 
@@ -180,6 +173,12 @@ pub struct Element {
     pub body: ElementBody,
 }
 
+impl From<NoElement> for Element {
+    fn from(value: NoElement) -> Self {
+        match value {}
+    }
+}
+
 impl MaybeElement for Element {
     fn should_parse(
         lookahead: &Lookahead1<'_>,
@@ -189,10 +188,6 @@ impl MaybeElement for Element {
         } else {
             None
         }
-    }
-
-    fn into_element(self) -> Element {
-        self
     }
 }
 

--- a/maud_macros/src/ast.rs
+++ b/maud_macros/src/ast.rs
@@ -143,10 +143,11 @@ impl<E: ToTokens> ToTokens for Markup<E> {
 /// allowed or not.
 pub trait MaybeElement: Sized + ToTokens {
     /// If an element can be parsed here, returns `Some` with a parser for the rest of the element.
-    fn should_parse(
-        lookahead: &Lookahead1<'_>,
-    ) -> Option<fn(ParseStream, &mut Vec<Diagnostic>) -> syn::Result<Self>>;
+    fn should_parse(lookahead: &Lookahead1<'_>) -> Option<DiagnosticParseFn<Self>>;
 }
+
+/// An implementation of `DiagnosticParse::diagnostic_parse`.
+pub type DiagnosticParseFn<T> = fn(ParseStream, &mut Vec<Diagnostic>) -> syn::Result<T>;
 
 /// Represents an attribute context, where elements are disallowed.
 #[derive(Debug, Clone)]

--- a/maud_macros/src/ast.rs
+++ b/maud_macros/src/ast.rs
@@ -773,21 +773,21 @@ impl ToTokens for ControlFlow {
 #[derive(Debug, Clone)]
 pub enum ControlFlowKind {
     Let(Local),
-    If(If),
-    For(For),
-    While(While),
-    Match(Match),
+    If(IfExpr),
+    For(ForExpr),
+    While(WhileExpr),
+    Match(MatchExpr),
 }
 
 #[derive(Debug, Clone)]
-pub struct If {
+pub struct IfExpr {
     pub if_token: Token![if],
     pub cond: Expr,
     pub then_branch: Block,
     pub else_branch: Option<(Token![@], Token![else], Box<IfOrBlock>)>,
 }
 
-impl DiagnosticParse for If {
+impl DiagnosticParse for IfExpr {
     fn diagnostic_parse(
         input: ParseStream,
         diagnostics: &mut Vec<Diagnostic>,
@@ -811,7 +811,7 @@ impl DiagnosticParse for If {
     }
 }
 
-impl ToTokens for If {
+impl ToTokens for IfExpr {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.if_token.to_tokens(tokens);
         self.cond.to_tokens(tokens);
@@ -826,7 +826,7 @@ impl ToTokens for If {
 
 #[derive(Debug, Clone)]
 pub enum IfOrBlock {
-    If(If),
+    If(IfExpr),
     Block(Block),
 }
 
@@ -857,7 +857,7 @@ impl ToTokens for IfOrBlock {
 }
 
 #[derive(Debug, Clone)]
-pub struct For {
+pub struct ForExpr {
     pub for_token: Token![for],
     pub pat: Pat,
     pub in_token: Token![in],
@@ -865,7 +865,7 @@ pub struct For {
     pub body: Block,
 }
 
-impl DiagnosticParse for For {
+impl DiagnosticParse for ForExpr {
     fn diagnostic_parse(
         input: ParseStream,
         diagnostics: &mut Vec<Diagnostic>,
@@ -880,7 +880,7 @@ impl DiagnosticParse for For {
     }
 }
 
-impl ToTokens for For {
+impl ToTokens for ForExpr {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.for_token.to_tokens(tokens);
         self.pat.to_tokens(tokens);
@@ -891,13 +891,13 @@ impl ToTokens for For {
 }
 
 #[derive(Debug, Clone)]
-pub struct While {
+pub struct WhileExpr {
     pub while_token: Token![while],
     pub cond: Expr,
     pub body: Block,
 }
 
-impl DiagnosticParse for While {
+impl DiagnosticParse for WhileExpr {
     fn diagnostic_parse(
         input: ParseStream,
         diagnostics: &mut Vec<Diagnostic>,
@@ -910,7 +910,7 @@ impl DiagnosticParse for While {
     }
 }
 
-impl ToTokens for While {
+impl ToTokens for WhileExpr {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.while_token.to_tokens(tokens);
         self.cond.to_tokens(tokens);
@@ -919,14 +919,14 @@ impl ToTokens for While {
 }
 
 #[derive(Debug, Clone)]
-pub struct Match {
+pub struct MatchExpr {
     pub match_token: Token![match],
     pub expr: Expr,
     pub brace_token: Brace,
     pub arms: Vec<MatchArm>,
 }
 
-impl DiagnosticParse for Match {
+impl DiagnosticParse for MatchExpr {
     fn diagnostic_parse(
         input: ParseStream,
         diagnostics: &mut Vec<Diagnostic>,
@@ -951,7 +951,7 @@ impl DiagnosticParse for Match {
     }
 }
 
-impl ToTokens for Match {
+impl ToTokens for MatchExpr {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.match_token.to_tokens(tokens);
         self.expr.to_tokens(tokens);

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -23,13 +23,13 @@ impl Generator {
         Builder::new(self.output_ident.clone())
     }
 
-    fn markups<E: MaybeElement>(&self, markups: Markups<E>, build: &mut Builder) {
+    fn markups<E: Into<Element>>(&self, markups: Markups<E>, build: &mut Builder) {
         for markup in markups.markups {
             self.markup(markup, build);
         }
     }
 
-    fn markup<E: MaybeElement>(&self, markup: Markup<E>, build: &mut Builder) {
+    fn markup<E: Into<Element>>(&self, markup: Markup<E>, build: &mut Builder) {
         match markup {
             Markup::Block(block) => {
                 if block.markups.markups.iter().any(|markup| {
@@ -48,13 +48,13 @@ impl Generator {
             }
             Markup::Lit(lit) => build.push_escaped(&lit.to_string()),
             Markup::Splice { expr, .. } => self.splice(expr, build),
-            Markup::Element(element) => self.element(element.into_element(), build),
+            Markup::Element(element) => self.element(element.into(), build),
             Markup::ControlFlow(control_flow) => self.control_flow(control_flow, build),
             Markup::Semi(_) => {}
         }
     }
 
-    fn block<E: MaybeElement>(&self, block: Block<E>, build: &mut Builder) {
+    fn block<E: Into<Element>>(&self, block: Block<E>, build: &mut Builder) {
         let markups = {
             let mut build = self.builder();
             self.markups(block.markups, &mut build);
@@ -184,7 +184,7 @@ impl Generator {
         }
     }
 
-    fn control_flow<E: MaybeElement>(&self, control_flow: ControlFlow<E>, build: &mut Builder) {
+    fn control_flow<E: Into<Element>>(&self, control_flow: ControlFlow<E>, build: &mut Builder) {
         match control_flow.kind {
             ControlFlowKind::If(if_) => self.control_flow_if(if_, build),
             ControlFlowKind::Let(let_) => self.control_flow_let(let_, build),
@@ -194,7 +194,7 @@ impl Generator {
         }
     }
 
-    fn control_flow_if<E: MaybeElement>(
+    fn control_flow_if<E: Into<Element>>(
         &self,
         IfExpr {
             if_token,
@@ -213,7 +213,7 @@ impl Generator {
         }
     }
 
-    fn control_flow_if_or_block<E: MaybeElement>(
+    fn control_flow_if_or_block<E: Into<Element>>(
         &self,
         if_or_block: IfOrBlock<E>,
         build: &mut Builder,
@@ -228,7 +228,7 @@ impl Generator {
         build.push_tokens(let_.to_token_stream());
     }
 
-    fn control_flow_for<E: MaybeElement>(
+    fn control_flow_for<E: Into<Element>>(
         &self,
         ForExpr {
             for_token,
@@ -243,7 +243,7 @@ impl Generator {
         self.block(body, build);
     }
 
-    fn control_flow_while<E: MaybeElement>(
+    fn control_flow_while<E: Into<Element>>(
         &self,
         WhileExpr {
             while_token,
@@ -256,7 +256,7 @@ impl Generator {
         self.block(body, build);
     }
 
-    fn control_flow_match<E: MaybeElement>(
+    fn control_flow_match<E: Into<Element>>(
         &self,
         MatchExpr {
             match_token,

--- a/maud_macros/src/generate.rs
+++ b/maud_macros/src/generate.rs
@@ -196,12 +196,12 @@ impl Generator {
 
     fn control_flow_if(
         &self,
-        If {
+        IfExpr {
             if_token,
             cond,
             then_branch,
             else_branch,
-        }: If,
+        }: IfExpr,
         build: &mut Builder,
     ) {
         build.push_tokens(quote!(#if_token #cond));
@@ -226,13 +226,13 @@ impl Generator {
 
     fn control_flow_for(
         &self,
-        For {
+        ForExpr {
             for_token,
             pat,
             in_token,
             expr,
             body,
-        }: For,
+        }: ForExpr,
         build: &mut Builder,
     ) {
         build.push_tokens(quote!(#for_token #pat #in_token (#expr)));
@@ -241,11 +241,11 @@ impl Generator {
 
     fn control_flow_while(
         &self,
-        While {
+        WhileExpr {
             while_token,
             cond,
             body,
-        }: While,
+        }: WhileExpr,
         build: &mut Builder,
     ) {
         build.push_tokens(quote!(#while_token #cond));
@@ -254,12 +254,12 @@ impl Generator {
 
     fn control_flow_match(
         &self,
-        Match {
+        MatchExpr {
             match_token,
             expr,
             brace_token,
             arms,
-        }: Match,
+        }: MatchExpr,
         build: &mut Builder,
     ) {
         let arms = {


### PR DESCRIPTION
Fixes a regression from #412. Alternate implementation of #459.

The following code was allowed, and this PR fixes the parser to ban it:

```rust
html! {
    a href={ b {} } {}
}
```