### PR TITLE
Avoid allocation when converting to axum's Response

### DIFF
--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -368,11 +368,10 @@ mod axum_support {
 
     impl IntoResponse for PreEscaped<String> {
         fn into_response(self) -> Response {
-            let mut headers = HeaderMap::new();
-            headers.insert(
+            let headers = [(
                 header::CONTENT_TYPE,
                 HeaderValue::from_static("text/html; charset=utf-8"),
-            );
+            )];
             (headers, self.0).into_response()
         }
     }


### PR DESCRIPTION
I have not bother benchmarking, but I believe avoiding allocating a HashMap will be easier to optimize and/or faster at runtime.