### PR TITLE
Add macro which uses pre-existing buffer for rendering

### DIFF
--- a/maud/benches/complicated_maud.rs
+++ b/maud/benches/complicated_maud.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use maud::{html, Markup};
+use maud::{html, html_render, Markup, Render};
 
 #[derive(Debug)]
 struct Entry {
@@ -11,7 +11,7 @@ struct Entry {
 }
 
 mod btn {
-    use maud::{html, Markup, Render};
+    use maud::{html_render, Render};
 
     #[derive(Copy, Clone)]
     pub enum RequestMethod {
@@ -42,24 +42,26 @@ mod btn {
     }
 
     impl Render for Button<'_> {
-        fn render(&self) -> Markup {
+        fn render_to(&self, buffer: &mut String) {
             match self.req_meth {
                 RequestMethod::Get => {
-                    html! { a.btn href=(self.path) { (self.label) } }
+                    let html = html_render! { a.btn href=(self.path) { (self.label) } };
+                    html.render_to(buffer);
                 }
                 RequestMethod::Post => {
-                    html! {
+                    let html = html_render! {
                         form method="POST" action=(self.path) {
                             input.btn type="submit" value=(self.label);
                         }
-                    }
+                    };
+                    html.render_to(buffer);
                 }
             }
         }
     }
 }
 
-fn layout<S: AsRef<str>>(title: S, inner: Markup) -> Markup {
+fn layout<S: AsRef<str>>(title: S, inner: impl Render) -> Markup {
     html! {
         html {
             head {
@@ -97,7 +99,7 @@ fn render_complicated_template(b: &mut test::Bencher) {
         use crate::btn::{Button, RequestMethod};
         layout(
             format!("Homepage of {year}"),
-            html! {
+            html_render! {
                 h1 { "Hello there!" }
 
                 @for entry in &teams {

--- a/maud/benches/complicated_maud.rs
+++ b/maud/benches/complicated_maud.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use maud::{html, html_render, Markup, Render};
+use maud::{Markup, Render, html, html_render};
 
 #[derive(Debug)]
 struct Entry {
@@ -11,7 +11,7 @@ struct Entry {
 }
 
 mod btn {
-    use maud::{html_render, Render};
+    use maud::{Render, html_render};
 
     #[derive(Copy, Clone)]
     pub enum RequestMethod {

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -477,7 +477,6 @@ pub mod macro_private {
     pub struct RenderFn<F>(pub F);
 
     impl<F: Fn(&mut String)> Render for RenderFn<F> {
-        #[inline(always)]
         fn render_to(&self, buffer: &mut String) {
             (self.0)(buffer)
         }

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -479,7 +479,7 @@ pub mod macro_private {
     impl<F: Fn(&mut String)> Render for RenderFn<F> {
         #[inline(always)]
         fn render_to(&self, buffer: &mut String) {
-            (&self.0)(buffer)
+            (self.0)(buffer)
         }
     }
 

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -16,6 +16,31 @@ use core::fmt::{self, Arguments, Display, Write};
 
 pub use maud_macros::html;
 
+/// Functionally the same as [`html`] but produces a struct that implements [`Render`].
+///
+/// You can
+///
+/// - Call `render()` to render the HTML as [`Markup`]
+/// - Call `render_to()` to render the HTML to a pre-existing `&mut String`
+/// - Pass this directly into an [`html`] invocation to add it as a component without allocating a new buffer.
+///
+/// ```
+/// use maud::{html, html_render, DOCTYPE};
+///
+/// let component = html_render! {
+///     p { "Wow, such component!" }
+/// };
+///
+/// let full = html! {
+///     (DOCTYPE)
+///     head {}
+///     html {
+///         (component)
+///     }
+/// };
+/// ```
+pub use maud_macros::html_render;
+
 mod escape;
 
 /// An adapter that escapes HTML special characters.
@@ -447,6 +472,16 @@ pub mod macro_private {
     use crate::{display, Render};
     use alloc::string::String;
     use core::fmt::Display;
+
+    #[repr(transparent)]
+    pub struct RenderFn<F>(pub F);
+
+    impl<F: Fn(&mut String)> Render for RenderFn<F> {
+        #[inline(always)]
+        fn render_to(&self, buffer: &mut String) {
+            (&self.0)(buffer)
+        }
+    }
 
     #[doc(hidden)]
     #[macro_export]

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -1,4 +1,4 @@
-use maud::{html, Markup};
+use maud::{html, html_render, Markup, Render};
 
 #[test]
 fn literals() {
@@ -371,5 +371,45 @@ fn div_shorthand_id_with_attrs() {
     assert_eq!(
         result.into_string(),
         r#"<div class="awesome-class" id="unique-id" contenteditable dir="rtl"></div>"#
+    );
+}
+
+#[test]
+fn html_component() {
+    let component = html_render! {
+        p {
+            "Hi!"
+            span { "Such component!" }
+        }
+    };
+
+    let result = html! {
+        (maud::DOCTYPE)
+        head {}
+        html {
+            h1 { ("Such webpage!") }
+            main {
+                (component)
+            }
+        }
+    };
+
+    let result_as_render = html_render! {
+        (maud::DOCTYPE)
+        head {}
+        html {
+            h1 { ("Such webpage!") }
+            main {
+                (component)
+            }
+        }
+    }
+    .render();
+
+    assert_eq!(result.0, result_as_render.0);
+
+    assert_eq!(
+        result.into_string(),
+        r#"<!DOCTYPE html><head></head><html><h1>Such webpage!</h1><main><p>Hi!<span>Such component!</span></p></main></html>"#
     );
 }

--- a/maud/tests/basic_syntax.rs
+++ b/maud/tests/basic_syntax.rs
@@ -1,4 +1,4 @@
-use maud::{html, html_render, Markup, Render};
+use maud::{Markup, Render, html, html_render};
 
 #[test]
 fn literals() {

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -56,7 +56,6 @@ fn expand(input: TokenStream, as_struct: bool) -> TokenStream {
             extern crate maud;
 
             maud::macro_private::RenderFn({
-                #[inline(always)]
                 |#output_ident: &mut String| {
                     #output_ident.reserve(#size_hint);
                     #stmts

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -58,6 +58,7 @@ fn expand(input: TokenStream, as_struct: bool) -> TokenStream {
             maud::macro_private::RenderFn({
                 #[inline(always)]
                 |#output_ident: &mut String| {
+                    #output_ident.reserve(#size_hint);
                     #stmts
                     #(#diag_tokens)*
                 }

--- a/maud_macros/src/lib.rs
+++ b/maud_macros/src/lib.rs
@@ -56,7 +56,7 @@ fn expand(input: TokenStream, as_struct: bool) -> TokenStream {
             extern crate maud;
 
             maud::macro_private::RenderFn({
-                |#output_ident: &mut String| {
+                |#output_ident: &mut alloc::string::String| {
                     #output_ident.reserve(#size_hint);
                     #stmts
                     #(#diag_tokens)*


### PR DESCRIPTION
This PR adds the `html_render` macro to this crate which produces a struct that is able to both render to a pre-existing buffer, *and also* be passed into another invocation of `html` and render inside of that without allocating a new buffer.

Here's the documentation I created for the new `html_render` macro:

Functionally the same as [`html`] but produces a struct that implements [`Render`].

You can

- Call `render()` to render the HTML as [`Markup`]
- Call `render_to()` to render the HTML to a pre-existing `&mut String`
- Pass this directly into an [`html`] invocation to add it as a component without allocating a new buffer.

```rust
use maud::{html, html_render, DOCTYPE};

let component = html_render! {
   p { "Wow, such component!" }
};

let full = html! {
   (DOCTYPE)
   head {}
   html {
       (component)
   }
};
```

This PR resolves #381 and #90 
