### PR TITLE
Avoid importing `alloc::sync` on platforms that do not have it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update to Rust 2024
   [#487](https://github.com/lambda-fairy/maud/pull/487)
+- Support platforms witout `alloc::sync` support.
+  [#491](https://github.com/lambda-fairy/maud/pull/491)
 
 ## [0.27.0] - 2025-02-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Update to Rust 2024
   [#487](https://github.com/lambda-fairy/maud/pull/487)
 - Support platforms witout `alloc::sync` support.
-  [#491](https://github.com/lambda-fairy/maud/pull/491)
+  [#492](https://github.com/lambda-fairy/maud/pull/492)
 
 ## [0.27.0] - 2025-02-02
 

--- a/maud/src/lib.rs
+++ b/maud/src/lib.rs
@@ -11,7 +11,7 @@
 
 extern crate alloc;
 
-use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc};
+use alloc::{borrow::Cow, boxed::Box, string::String};
 use core::fmt::{self, Arguments, Display, Write};
 
 pub use maud_macros::html;
@@ -150,7 +150,8 @@ impl<T: Render + ?Sized> Render for Box<T> {
     }
 }
 
-impl<T: Render + ?Sized> Render for Arc<T> {
+#[cfg(target_has_atomic = "ptr")]
+impl<T: Render + ?Sized> Render for alloc::sync::Arc<T> {
     fn render_to(&self, w: &mut String) {
         T::render_to(self, w);
     }


### PR DESCRIPTION
While trying to test another crate (which depends on `maud`) under `no_std` conditions, I found that this won't compile as-is on my go-to baseline target for that (usually [`thumbv6m-none-eabi`](https://doc.rust-lang.org/nightly/rustc/platform-support/thumbv6m-none-eabi.html)), due to a lack of atomic pointer support. (`thumbv7m-none-eabi` seems to work fine however.)

Since `maud` only seems to import `Arc` to add a `Render` impl, I suppose it wouldn't affect anything to simply move that impl block behind an appropriate `cfg` attribute so it won't be included when building for affected platforms. This PR does just that.

In terms of tests, I could add a CI step to try building against `thumbv6m-none-eabi` if you'd like, but I figured I'd ask on that one, since `no_std` support seems to work well here otherwise.