### PR TITLE
Ensure no_std builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
     - name: Check Clippy
       run: cargo clippy --workspace --all-targets -- -D warnings
 
+    # Building --all-targets for a no_std environment fails because the tests depend on std
+    - name: Try no_std build
+      run: |
+        rustup target add thumbv6m-none-eabi
+        cargo build --release --workspace --lib --bins --examples --target thumbv6m-none-eabi
+
   # Please keep this in sync with `publish-docs.yml`
   documentation:
     name: Documentation


### PR DESCRIPTION
Follow-up to #492, this PR adds a CI step to ensure maud continues to build in `no_std` environments (in this case, the `thumbv6m-none-eabi` target, which has only `core` and `alloc`, minus atomic pointers).