### PR TITLE
Build Tide without optional features

### DIFF
--- a/doctest/Cargo.toml
+++ b/doctest/Cargo.toml
@@ -12,7 +12,7 @@ pulldown-cmark = "0.13"
 rocket = "0.5"
 rouille = "3"
 submillisecond = "0.4.1"
-tide = "0.16"
+tide = { version = "0.16", default-features = false }
 tokio = { version = "1.9.0", features = ["rt", "macros", "rt-multi-thread"] }
 axum = "0.8"
 warp = { version = "0.4", features = ["server"] }


### PR DESCRIPTION
```
error: attributes starting with `rustc` are reserved for use by the `rustc` compiler
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-0.37.28/src/backend/linux_raw/io/errno.rs:28:25
   |
28 | #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0xf001))]
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: attributes starting with `rustc` are reserved for use by the `rustc` compiler
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-0.37.28/src/backend/linux_raw/io/errno.rs:29:25
   |
29 | #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_end(0xffff))]
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: cannot find attribute `rustc_layout_scalar_valid_range_start` in this scope
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-0.37.28/src/backend/linux_raw/io/errno.rs:28:25
   |
28 | #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0xf001))]
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: cannot find attribute `rustc_layout_scalar_valid_range_end` in this scope
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustix-0.37.28/src/backend/linux_raw/io/errno.rs:29:25
   |
29 | #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_end(0xffff))]
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```