### PR TITLE
Handle stable warning snapshots

### DIFF
--- a/maud/Cargo.toml
+++ b/maud/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
+rustversion = "1"
 trybuild = { version = "1.0.33", features = ["diff"] }
 
 [package.metadata.docs.rs]

--- a/maud/tests/errors.rs
+++ b/maud/tests/errors.rs
@@ -1,7 +1,22 @@
 use trybuild::TestCases;
 
 #[test]
+#[rustversion::nightly]
 fn run_warnings() {
     let config = TestCases::new();
     config.compile_fail("tests/warnings/*.rs");
+}
+
+#[test]
+#[rustversion::not(nightly)]
+fn run_warnings() {
+    let config = TestCases::new();
+
+    config.compile_fail("tests/warnings/attribute-missing-value.rs");
+    config.compile_fail("tests/warnings/class-shorthand-missing-value.rs");
+    config.compile_fail("tests/warnings/dynamic-attribute-names.rs");
+    config.compile_fail("tests/warnings/elements-in-attributes.rs");
+    config.compile_fail("tests/warnings/let-without-block.rs");
+    config.compile_fail("tests/warnings/non-closed-element.rs");
+    config.compile_fail("tests/warnings-stable/*.rs");
 }

--- a/maud/tests/warnings-stable/keyword-without-at.rs
+++ b/maud/tests/warnings-stable/keyword-without-at.rs
@@ -1,0 +1,11 @@
+use maud::html;
+
+fn main() {
+    html! {
+        if {}
+        else {}
+        for {}
+        while {}
+        match {}
+    };
+}

--- a/maud/tests/warnings-stable/keyword-without-at.stderr
+++ b/maud/tests/warnings-stable/keyword-without-at.stderr
@@ -1,0 +1,34 @@
+error: found keyword `if`
+       = help: should this be `@if`?
+ --> tests/warnings-stable/keyword-without-at.rs:5:9
+  |
+5 |         if {}
+  |         ^^
+
+error: found keyword `else`
+       = help: should this be `@else`?
+ --> tests/warnings-stable/keyword-without-at.rs:6:9
+  |
+6 |         else {}
+  |         ^^^^
+
+error: found keyword `for`
+       = help: should this be `@for`?
+ --> tests/warnings-stable/keyword-without-at.rs:7:9
+  |
+7 |         for {}
+  |         ^^^
+
+error: found keyword `while`
+       = help: should this be `@while`?
+ --> tests/warnings-stable/keyword-without-at.rs:8:9
+  |
+8 |         while {}
+  |         ^^^^^
+
+error: found keyword `match`
+       = help: should this be `@match`?
+ --> tests/warnings-stable/keyword-without-at.rs:9:9
+  |
+9 |         match {}
+  |         ^^^^^

--- a/maud/tests/warnings-stable/non-string-literal.rs
+++ b/maud/tests/warnings-stable/non-string-literal.rs
@@ -1,0 +1,16 @@
+use maud::html;
+
+fn main() {
+    html! {
+        42
+        42usize
+        42.0
+        'a'
+        b"a"
+        b'a'
+
+        // `true` and `false` are only considered literals in attribute values
+        input disabled=true;
+        input disabled=false;
+    };
+}

--- a/maud/tests/warnings-stable/non-string-literal.stderr
+++ b/maud/tests/warnings-stable/non-string-literal.stderr
@@ -1,0 +1,51 @@
+error: literal must be double-quoted: `"42"`
+ --> tests/warnings-stable/non-string-literal.rs:5:9
+  |
+5 |         42
+  |         ^^
+
+error: literal must be double-quoted: `"42usize"`
+ --> tests/warnings-stable/non-string-literal.rs:6:9
+  |
+6 |         42usize
+  |         ^^^^^^^
+
+error: literal must be double-quoted: `"42.0"`
+ --> tests/warnings-stable/non-string-literal.rs:7:9
+  |
+7 |         42.0
+  |         ^^^^
+
+error: literal must be double-quoted: `"a"`
+ --> tests/warnings-stable/non-string-literal.rs:8:9
+  |
+8 |         'a'
+  |         ^^^
+
+error: expected string
+ --> tests/warnings-stable/non-string-literal.rs:9:9
+  |
+9 |         b"a"
+  |         ^^^^
+
+error: expected string
+  --> tests/warnings-stable/non-string-literal.rs:10:9
+   |
+10 |         b'a'
+   |         ^^^^
+
+error: attribute value must be a string
+       = help: to declare an empty attribute, omit the equals sign: `disabled`
+       = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
+  --> tests/warnings-stable/non-string-literal.rs:13:15
+   |
+13 |         input disabled=true;
+   |               ^^^^^^^^^^^^^
+
+error: attribute value must be a string
+       = help: to declare an empty attribute, omit the equals sign: `disabled`
+       = help: to toggle the attribute, use square brackets: `disabled[some_boolean_flag]`
+  --> tests/warnings-stable/non-string-literal.rs:14:15
+   |
+14 |         input disabled=false;
+   |               ^^^^^^^^^^^^^^

--- a/maud/tests/warnings-stable/void-element-slash.rs
+++ b/maud/tests/warnings-stable/void-element-slash.rs
@@ -1,0 +1,9 @@
+use maud::html;
+
+fn main() {
+    html! {
+        br /
+        // Make sure we're not stopping on the first error
+        input type="text" /
+    };
+}

--- a/maud/tests/warnings-stable/void-element-slash.stderr
+++ b/maud/tests/warnings-stable/void-element-slash.stderr
@@ -1,0 +1,15 @@
+error: void elements must use `;`, not `/`
+       = help: change this to `;`
+       = help: see https://github.com/lambda-fairy/maud/pull/315 for details
+ --> tests/warnings-stable/void-element-slash.rs:5:12
+  |
+5 |         br /
+  |            ^
+
+error: void elements must use `;`, not `/`
+       = help: change this to `;`
+       = help: see https://github.com/lambda-fairy/maud/pull/315 for details
+ --> tests/warnings-stable/void-element-slash.rs:7:27
+  |
+7 |         input type="text" /
+  |                           ^


### PR DESCRIPTION
This addresses #498.

The warning tests compare trybuild stderr fixtures. The existing fixtures match the nightly diagnostic rendering used by the repository CI, while the Debian report shows the stable-style rendering for three diagnostics where help notes are printed before the source location.

This keeps the current nightly warning run unchanged and adds stable-specific fixtures for those three cases. On nightly, the test still runs `tests/warnings/*.rs`; on non-nightly, it runs the unaffected warning cases plus the stable fixtures.

Verification:
- `git diff --check`
- `git show --check --oneline HEAD`
- Compared the stable fixtures against the actual output in #498

I could not run `cargo test -p maud --test errors run_warnings` locally in this environment because `cargo` is not installed on PATH. The first CI run showed the original fixture replacement was wrong for nightly, so I amended this to keep the nightly fixtures unchanged and add non-nightly fixtures instead.